### PR TITLE
[#10] Rename ddev project

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,4 +1,4 @@
-name: craft-starter
+name: viget-craft-starter
 type: craftcms
 docroot: web
 php_version: "8.2"


### PR DESCRIPTION
- #10


Renames the `ddev` project name in the config.

This prevents DDEV from complaining that "this project is already listed" if https://github.com/AdCouncil/craft-starter/ is already locally installed and set up.

Is this an OK change? 