### PR TITLE
[#52] Form components

### DIFF
--- a/config/tailwind/forms.js
+++ b/config/tailwind/forms.js
@@ -57,7 +57,7 @@ export default plugin(({ addComponents }) => {
         backgroundRepeat: 'no-repeat',
         '@apply appearance-none pr-32': {},
 
-        '[data-theme="dark"] &': {
+        '.dark &': {
           backgroundImage: `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23ffffff' d='M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z'/%3E%3C/svg%3E")`,
         },
         '& option': {

--- a/config/tailwind/forms.js
+++ b/config/tailwind/forms.js
@@ -55,7 +55,7 @@ export default plugin(({ addComponents }) => {
       },
       // required field styles
       '&[data-required] label .field-label::after': {
-        '@apply content-["*"] text-red-500 align-super text-xs ml-2 font-medium':
+        '@apply content-["*"] text-red-600 align-super text-xs ml-2 font-medium dark:text-red-300':
           {},
       },
       '&[data-required="long"] label .field-label::after': {
@@ -64,10 +64,11 @@ export default plugin(({ addComponents }) => {
       // error field styles
       '&[data-state="error"] input[type="text"], &[data-state="error"] input[type="password"], &[data-state="error"] input[type="email"], &[data-state="error"] input[type="number"], &[data-state="error"] input[type="tel"], &[data-state="error"] select, &[data-state="error"] textarea, &[data-state="error"] input[type="checkbox"]':
         {
-          '@apply ring-red-500 hover:ring-red-600 focus:ring-red-500': {},
+          '@apply ring-red-600 hover:ring-red-700 focus:ring-red-600 dark:ring-red-300 dark:hover:ring-red-400 dark:focus:ring-red-300':
+            {},
         },
       '.field-errors': {
-        '@apply relative text-red-500 text-sm font-medium flex gap-10 flex-col pl-20 list-none':
+        '@apply relative text-red-600 text-sm font-medium flex gap-10 flex-col pl-20 list-none dark:text-red-300':
           {},
       },
     },

--- a/config/tailwind/forms.js
+++ b/config/tailwind/forms.js
@@ -1,0 +1,77 @@
+import plugin from 'tailwindcss/plugin'
+
+export default plugin(({ addComponents }) => {
+  // Base styles
+  const inputs = {
+    '.field-group': {
+      '@apply flex flex-col gap-8': {},
+      // label container
+      '& label': {
+        '@apply flex flex-col [&:has(.sr-only:last-child)]:sr-only': {},
+      },
+      // label
+      '& .field-label': {
+        '@apply text-gray-900 dark:text-white': {},
+      },
+      // sublabel & instructions
+      '& .field-sublabel, & .field-instructions': {
+        '@apply text-sm text-gray-700 dark:text-gray-300': {},
+      },
+      // core field styles
+      '& input[type="text"], & input[type="password"], & input[type="email"], & input[type="number"], & input[type="tel"], & input[type="url"], & select, & textarea':
+        {
+          // base styles
+          '@apply h-40 rounded-sm border-0 bg-white ring-1 outline-none ring-black/50 px-8 dark:bg-white/10 dark:text-white dark:ring-white/50':
+            {},
+          // placeholder styles
+          '@apply placeholder:text-black/40 dark:placeholder:text-white/50': {},
+          // hover styles
+          '@apply hover:ring-black/75 dark:hover:ring-white/75': {},
+          // focus styles
+          '@apply focus:ring-blue-500 focus:ring-2 dark:focus:ring-white/75':
+            {},
+          // disabled styles
+          '@apply disabled:bg-gray-500/10 disabled:ring-gray-500/20 disabled:text-black/75 disabled:cursor-not-allowed dark:disabled:ring-white/20 dark:disabled:bg-white/25 dark:disabled:text-white/50 dark:disabled:placeholder:text-white/35':
+            {},
+          '&:is(input[type="checkbox"])': {
+            '@apply size-20 border-0 text-blue-500 checked:bg-blue-500 min-h-0':
+              {},
+          },
+        },
+      // field specific styles
+      '& select': {
+        backgroundImage: `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000000' d='M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z'/%3E%3C/svg%3E")`,
+        backgroundPosition: 'right .5rem center',
+        backgroundSize: '1rem',
+        backgroundRepeat: 'no-repeat',
+        '@apply appearance-none pr-32': {},
+
+        '[data-theme="dark"] &': {
+          backgroundImage: `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23ffffff' d='M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z'/%3E%3C/svg%3E")`,
+        },
+        '& option': {
+          '@apply text-black': {},
+        },
+      },
+      // required field styles
+      '&[data-required] label .field-label::after': {
+        '@apply content-["*"] text-red-500 align-super text-xs ml-2 font-medium':
+          {},
+      },
+      '&[data-required="long"] label .field-label::after': {
+        '@apply content-["*Required"]': {},
+      },
+      // error field styles
+      '&[data-state="error"] input[type="text"], &[data-state="error"] input[type="password"], &[data-state="error"] input[type="email"], &[data-state="error"] input[type="number"], &[data-state="error"] input[type="tel"], &[data-state="error"] select, &[data-state="error"] textarea, &[data-state="error"] input[type="checkbox"]':
+        {
+          '@apply ring-red-500 hover:ring-red-600 focus:ring-red-500': {},
+        },
+      '.field-errors': {
+        '@apply relative text-red-500 text-sm font-medium flex gap-10 flex-col pl-20 list-none':
+          {},
+      },
+    },
+  }
+
+  addComponents(inputs)
+})

--- a/config/tailwind/forms.js
+++ b/config/tailwind/forms.js
@@ -21,7 +21,7 @@ export default plugin(({ addComponents }) => {
       '& input[type="text"], & input[type="password"], & input[type="email"], & input[type="number"], & input[type="tel"], & input[type="url"], & select, & textarea':
         {
           // base styles
-          '@apply h-40 rounded-sm border-0 bg-white ring-1 outline-none ring-black/50 px-8 dark:bg-white/10 dark:text-white dark:ring-white/50':
+          '@apply rounded-sm border-0 bg-white ring-1 outline-none ring-black/50 px-8 dark:bg-white/10 dark:text-white dark:ring-white/50':
             {},
           // placeholder styles
           '@apply placeholder:text-black/40 dark:placeholder:text-white/50': {},
@@ -33,6 +33,10 @@ export default plugin(({ addComponents }) => {
           // disabled styles
           '@apply disabled:bg-gray-500/10 disabled:ring-gray-500/20 disabled:text-black/75 disabled:cursor-not-allowed dark:disabled:ring-white/20 dark:disabled:bg-white/25 dark:disabled:text-white/50 dark:disabled:placeholder:text-white/35':
             {},
+          // Exclude textarea from fix height
+          '&:not(textarea)': {
+            '@apply h-40': {},
+          },
           '&:is(input[type="checkbox"])': {
             '@apply size-20 border-0 text-blue-500 checked:bg-blue-500 min-h-0':
               {},
@@ -43,6 +47,9 @@ export default plugin(({ addComponents }) => {
           },
         },
       // field specific styles
+      '& textarea': {
+        '@apply py-8': {},
+      },
       '& select': {
         backgroundImage: `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000000' d='M12 5.83 15.17 9l1.41-1.41L12 3 7.41 7.59 8.83 9 12 5.83zm0 12.34L8.83 15l-1.41 1.41L12 21l4.59-4.59L15.17 15 12 18.17z'/%3E%3C/svg%3E")`,
         backgroundPosition: 'right .5rem center',

--- a/config/tailwind/forms.js
+++ b/config/tailwind/forms.js
@@ -37,6 +37,10 @@ export default plugin(({ addComponents }) => {
             '@apply size-20 border-0 text-blue-500 checked:bg-blue-500 min-h-0':
               {},
           },
+          '&:is([aria-invalid="true"])': {
+            '@apply ring-red-600 hover:ring-red-700 focus:ring-red-600 dark:ring-red-300 dark:hover:ring-red-400 dark:focus:ring-red-300':
+              {},
+          },
         },
       // field specific styles
       '& select': {
@@ -61,12 +65,7 @@ export default plugin(({ addComponents }) => {
       '&[data-required="long"] label .field-label::after': {
         '@apply content-["*Required"]': {},
       },
-      // error field styles
-      '&[data-state="error"] input[type="text"], &[data-state="error"] input[type="password"], &[data-state="error"] input[type="email"], &[data-state="error"] input[type="number"], &[data-state="error"] input[type="tel"], &[data-state="error"] select, &[data-state="error"] textarea, &[data-state="error"] input[type="checkbox"]':
-        {
-          '@apply ring-red-600 hover:ring-red-700 focus:ring-red-600 dark:ring-red-300 dark:hover:ring-red-400 dark:focus:ring-red-300':
-            {},
-        },
+      // error message styles
       '.field-errors': {
         '@apply relative text-red-600 text-sm font-medium flex gap-10 flex-col pl-20 list-none dark:text-red-300':
           {},

--- a/src/icons/error.svg
+++ b/src/icons/error.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+  stroke-linecap="round" stroke-linejoin="round">
+  <line x1="12" y1="9" x2="12" y2="13"></line>
+  <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+  <line x1="12" y1="17" x2="12.01" y2="17"></line>
+</svg>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,7 +15,7 @@ function pxPair(value) {
 
 /** @type {import('tailwindcss').Config} */
 export default {
-  darkMode: 'class',
+  darkMode: 'selector',
   content: ['./templates/**/*.{twig,html}', './src/**/*.{js,jsx,ts,tsx,svg}'],
   corePlugins: {
     container: false, // Replaced with a custom container class

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,7 @@ function pxPair(value) {
 
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./templates/**/*.{twig,html}', './src/**/*.{js,jsx,ts,tsx,svg}'],
   corePlugins: {
     container: false, // Replaced with a custom container class

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@ import buttons from './config/tailwind/buttons'
 import dialog from './config/tailwind/dialog'
 import richText from './config/tailwind/rich-text'
 import container from './config/tailwind/container'
+import forms from './config/tailwind/forms'
 
 /**
  Helper function to pair key and value together
@@ -69,5 +70,5 @@ export default {
       },
     },
   },
-  plugins: [buttons, dialog, richText, container],
+  plugins: [buttons, dialog, richText, container, forms],
 }

--- a/templates/_components/field-group.twig
+++ b/templates/_components/field-group.twig
@@ -1,5 +1,10 @@
 {% from '_macros/icon.twig' import icon %}
 
+{# @var id string #}
+{% set id = id ?? ('input-' ~ random()) %}
+
+{% set class = class ?? null %}
+
 {# @var fieldElement string - Required #}
 {% set fieldElement = fieldElement %}
 
@@ -26,7 +31,6 @@
 
 
 {# Generated vars #}
-{% set id = 'input-' ~ random() %}
 {% set idErrors = id ~ '-errors' %}
 {% set idInstructions = id ~ '-instructions' %}
 {% set hasError = errorMessages|length %}
@@ -37,7 +41,7 @@
 ]|filter|join(' ') %}
 
 <div {{ attr({
-  class: 'field-group',
+  class: cx('field-group', class),
   'data-required': dataRequired,
 }) }}>
   <label for="{{ id }}">
@@ -56,13 +60,15 @@
     {% endif %}
   </label>
 
-  {{ tag(fieldElement, {
+  {% tag fieldElement with {
     ...fieldAttrs,
     id,
     'aria-required': required ? 'true' : null,
     'aria-describedby': describedByElements ? describedByElements : null,
     'aria-invalid': hasError ? 'true' : null,
-  }) }}
+    required: required is same as false ? null : '',
+  } -%}
+  {%- endtag %}
 
   {% if instructions %}
     <span class="field-instructions" id="{{ idInstructions }}">

--- a/templates/_components/field-group.twig
+++ b/templates/_components/field-group.twig
@@ -1,0 +1,87 @@
+{% from '_macros/icon.twig' import icon %}
+
+{# @var fieldElement string #}
+{% set fieldElement = fieldElement ?? 'input' %}
+
+{# @var label string|null #}
+{% set label = label ?? null %}
+
+{# @var labelHidden bool #}
+{% set labelHidden = labelHidden ?? false %}
+
+{# @var required bool|string long is an option in addition to true #}
+{% set required = required ?? false %}
+
+{# @var subLabel string|null #}
+{% set subLabel = subLabel ?? null %}
+
+{# @var instructions string|null #}
+{% set instructions = instructions ?? null %}
+
+{# @var errorMessages string[] #}
+{% set errorMessages = errorMessages ?? [] %}
+
+{# This prop is inherited from field-* components #}
+
+{# @var fieldAttrs array #}
+{% set fieldAttrs = fieldAttrs ?? {} %}
+
+{# Generated vars #}
+{% set id = 'input-' ~ random() %}
+{% set idErrors = id ~ '-errors' %}
+{% set idInstructions = id ~ '-instructions' %}
+{% set hasError = errorMessages|length %}
+{% set dataRequired = required ? (required is same as 'long' ? 'long' : true) : null %}
+{% set describedByElements = [
+  instructions ? idInstructions,
+  hasError ? idErrors,
+]|filter|join(' ') %}
+
+<div {{ attr({
+  class: 'field-group',
+  'data-required': dataRequired,
+}) }}>
+  <label for="{{ id }}">
+    {% if label %}
+      <span {{ attr({
+        class: cx('field-label', {
+          'sr-only': labelHidden,
+        }),
+      }) }}>
+        {{ label }}
+      </span>
+    {% endif %}
+
+    {% if subLabel %}
+      <span class="field-sublabel">{{ subLabel }}</span>
+    {% endif %}
+  </label>
+
+  {{ tag(fieldElement, {
+    ...fieldAttrs,
+    id,
+    'aria-required': required ? 'true' : null,
+    'aria-describedby': describedByElements ? describedByElements : null,
+    'aria-invalid': hasError ? 'true' : null,
+  }) }}
+
+  {% if instructions %}
+    <span class="field-instructions" id="{{ idInstructions }}">
+      {{ instructions }}
+    </span>
+  {% endif %}
+
+  {% if hasError %}
+    <ul class="field-errors" id="{{ idErrors }}">
+      {{ icon({
+        name: 'error',
+        class: 'absolute left-0 top-2 shrink-0',
+        size: 'sm',
+      }) }}
+
+      {% for error in errorMessages %}
+        <li>{{ error }}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+</div>

--- a/templates/_components/field-group.twig
+++ b/templates/_components/field-group.twig
@@ -40,6 +40,7 @@
 <div {{ attr({
   class: 'field-group',
   'data-required': dataRequired,
+  'data-state': hasError ? 'error' : null,
 }) }}>
   <label for="{{ id }}">
     {% if label %}

--- a/templates/_components/field-group.twig
+++ b/templates/_components/field-group.twig
@@ -40,7 +40,6 @@
 <div {{ attr({
   class: 'field-group',
   'data-required': dataRequired,
-  'data-state': hasError ? 'error' : null,
 }) }}>
   <label for="{{ id }}">
     {% if label %}

--- a/templates/_components/field-group.twig
+++ b/templates/_components/field-group.twig
@@ -1,7 +1,10 @@
 {% from '_macros/icon.twig' import icon %}
 
-{# @var fieldElement string #}
-{% set fieldElement = fieldElement ?? 'input' %}
+{# @var fieldElement string - Required #}
+{% set fieldElement = fieldElement %}
+
+{# @var fieldAttrs array #}
+{% set fieldAttrs = fieldAttrs ?? {} %}
 
 {# @var label string|null #}
 {% set label = label ?? null %}
@@ -21,10 +24,6 @@
 {# @var errorMessages string[] #}
 {% set errorMessages = errorMessages ?? [] %}
 
-{# This prop is inherited from field-* components #}
-
-{# @var fieldAttrs array #}
-{% set fieldAttrs = fieldAttrs ?? {} %}
 
 {# Generated vars #}
 {% set id = 'input-' ~ random() %}

--- a/templates/_components/field-group.twig
+++ b/templates/_components/field-group.twig
@@ -1,15 +1,29 @@
+{#
+The field group component is a wrapper for our field components.
+It provides consistent styling for labels, sublabels, instructions, and error messages.
+
+The {% tag fieldElement %} tag is used to render the field element. It can be
+configured as an input, select, textarea, or other field element.
+
+The field attrs hash is used to pass additional attributes to the field element.
+#}
+
 {% from '_macros/icon.twig' import icon %}
 
 {# @var id string #}
 {% set id = id ?? ('input-' ~ random()) %}
 
+{# @var class string|null #}
 {% set class = class ?? null %}
 
 {# @var fieldElement string - Required #}
 {% set fieldElement = fieldElement %}
 
-{# @var fieldAttrs array #}
+{# @var fieldAttrs array - Additional attributes to pass to the field element #}
 {% set fieldAttrs = fieldAttrs ?? {} %}
+
+{# @var fieldChildren array|null An array of elements to render inside the field element, used for select dropdowns #}
+{% set fieldChildren = fieldChildren ?? []%}
 
 {# @var label string|null #}
 {% set label = label ?? null %}
@@ -68,6 +82,9 @@
     'aria-invalid': hasError ? 'true' : null,
     required: required is same as false ? null : '',
   } -%}
+    {% for child in fieldChildren %}
+      {{ child }}
+    {% endfor %}
   {%- endtag %}
 
   {% if instructions %}

--- a/templates/_components/field-select.twig
+++ b/templates/_components/field-select.twig
@@ -1,0 +1,76 @@
+{# These props mirror the props in field-group.twig #}
+
+{# @var id string #}
+{% set id = id ?? null %}
+
+{# @var class string|null #}
+{% set class = class ?? null %}
+
+{# @var fieldAttrs array #}
+{% set fieldAttrs = fieldAttrs ?? {} %}
+
+{# @var label string|null #}
+{% set label = label ?? null %}
+
+{# @var labelHidden bool #}
+{% set labelHidden = labelHidden ?? false %}
+
+{# @var required bool #}
+{% set required = required ?? false %}
+
+{# @var subLabel string|null #}
+{% set subLabel = subLabel ?? null %}
+
+{# @var instructions string|null #}
+{% set instructions = instructions ?? null %}
+
+{# @var errorMessages string[] #}
+{% set errorMessages = errorMessages ?? [] %}
+
+{# These props are for the select element #}
+
+{# @var name string|null #}
+{% set name = name ?? null %}
+
+{# @var placeholder string|null Only used when a blank option is present #}
+{% set placeholder = placeholder ?? null %}
+
+{# @var useEmptyOption bool #}
+{% set useEmptyOption = useEmptyOption ?? false %}
+
+{# @var disabled bool #}
+{% set disabled = disabled ?? false %}
+
+{# @var options array{label: string, value: string, selected: bool}[] #}
+{% set options = options ?? [] %}
+
+{% macro option(item) %}
+  <option {{ attr({
+    value: item.value ?? '',
+    selected: item.selected is defined ? '' : null,
+  }) }}>
+    {{ item.label }}
+  </option>
+{% endmacro %}
+
+{% if useEmptyOption %}
+  {% set options = options|unshift({label: placeholder, value: '' }) %}
+{% endif %}
+
+{{ include('_components/field-group.twig', {
+  fieldElement: 'select',
+  fieldAttrs: {
+    ...fieldAttrs,
+    name,
+    disabled: disabled ? '' : null,
+  },
+  id,
+  class,
+  fieldChildren: options|map(item => _self.option(item)),
+  label,
+  labelHidden,
+  required,
+  subLabel,
+  instructions,
+  errorMessages,
+}) }}

--- a/templates/_components/field-text-input.twig
+++ b/templates/_components/field-text-input.twig
@@ -1,0 +1,56 @@
+{# These props mirror the props in field-group.twig #}
+
+{# @var fieldElement string #}
+{% set fieldElement = fieldElement ?? 'input' %}
+
+{# @var fieldAttrs array #}
+{% set fieldAttrs = fieldAttrs ?? {} %}
+
+{# @var label string|null #}
+{% set label = label ?? null %}
+
+{# @var labelHidden bool #}
+{% set labelHidden = labelHidden ?? false %}
+
+{# @var required bool #}
+{% set required = required ?? false %}
+
+{# @var subLabel string|null #}
+{% set subLabel = subLabel ?? null %}
+
+{# @var instructions string|null #}
+{% set instructions = instructions ?? null %}
+
+{# @var errorMessages string[] #}
+{% set errorMessages = errorMessages ?? [] %}
+
+{# These props are specific to this component #}
+
+{# @var placeholder string|null #}
+{% set placeholder = placeholder ?? null %}
+
+{# @var disabled bool #}
+{% set disabled = disabled ?? false %}
+
+{# @var type string|null #}
+{% set type = type ?? 'text' %}
+
+{# Allowed types #}
+{% set allowedTypes = ['text', 'password', 'email', 'number', 'tel', 'url'] %}
+{% set validatedType = type in allowedTypes ? type : 'text' %}
+
+
+{{ include('_components/field-group.twig', {
+  fieldElement: 'input',
+  fieldAttrs: {
+    type: validatedType,
+    placeholder,
+    disabled: disabled ? '' : null,
+  },
+  label,
+  labelHidden,
+  required,
+  subLabel,
+  instructions,
+  errorMessages,
+}) }}

--- a/templates/_components/field-text-input.twig
+++ b/templates/_components/field-text-input.twig
@@ -1,5 +1,11 @@
 {# These props mirror the props in field-group.twig #}
 
+{# @var id string #}
+{% set id = id ?? null %}
+
+{# @var class string|null #}
+{% set class = class ?? null %}
+
 {# @var fieldAttrs array #}
 {% set fieldAttrs = fieldAttrs ?? {} %}
 
@@ -48,6 +54,8 @@
     placeholder,
     disabled: disabled ? '' : null,
   },
+  id,
+  class,
   label,
   labelHidden,
   required,

--- a/templates/_components/field-text-input.twig
+++ b/templates/_components/field-text-input.twig
@@ -26,6 +26,9 @@
 
 {# These props are specific to this component #}
 
+{# @var name string|null #}
+{% set name = name ?? null %}
+
 {# @var placeholder string|null #}
 {% set placeholder = placeholder ?? null %}
 

--- a/templates/_components/field-textarea.twig
+++ b/templates/_components/field-textarea.twig
@@ -1,5 +1,11 @@
 {# These props mirror the props in field-group.twig #}
 
+{# @var id string #}
+{% set id = id ?? null %}
+
+{# @var class string|null #}
+{% set class = class ?? null %}
+
 {# @var fieldAttrs array #}
 {% set fieldAttrs = fieldAttrs ?? {} %}
 
@@ -53,6 +59,8 @@
     disabled: disabled ? '' : null,
     rows,
   },
+  id,
+  class,
   label,
   labelHidden,
   required,

--- a/templates/_components/field-textarea.twig
+++ b/templates/_components/field-textarea.twig
@@ -21,7 +21,7 @@
 {# @var errorMessages string[] #}
 {% set errorMessages = errorMessages ?? [] %}
 
-{# These props are for the input element #}
+{# These props are for the textarea element #}
 
 {# @var name string|null #}
 {% set name = name ?? null %}
@@ -32,21 +32,26 @@
 {# @var disabled bool #}
 {% set disabled = disabled ?? false %}
 
-{# @var type string|null #}
-{% set type = type ?? 'text' %}
+{# @var rows int #}
+{% set rows = rows ?? 4 %}
 
-{# Allowed types #}
-{% set allowedTypes = ['text', 'password', 'email', 'number', 'tel', 'url'] %}
-{% set validatedType = type in allowedTypes ? type : 'text' %}
+{# @var resize bool #}
+{% set resize = resize ?? false %}
 
 {{ include('_components/field-group.twig', {
-  fieldElement: 'input',
+  fieldElement: 'textarea',
   fieldAttrs: {
     ...fieldAttrs,
+    class: cx(
+      fieldAttrs.class ?? null,
+      {
+        'resize-none': not resize,
+      },
+    ),
     name,
-    type: validatedType,
     placeholder,
     disabled: disabled ? '' : null,
+    rows,
   },
   label,
   labelHidden,

--- a/templates/_layouts/base.twig
+++ b/templates/_layouts/base.twig
@@ -18,16 +18,23 @@
     {% endif %}
 
     {{ craft.vite.script('src/js/app.js', false) }}
+
+    {# Hide elements if we're in the parts-kit #}
+    {% set isPartsKitUrl = craft.app.request.segments | first == 'parts-kit' %}
 </head>
 <body>
 
-    {% include "_partials/header.twig" %}
+    {% if not isPartsKitUrl %}
+        {{ include('_partials/header.twig') }}
+    {% endif %}
 
     <main id="content" tabindex="-1">
         {% block content %}{% endblock %}
     </main>
 
-    {% include "_partials/footer.twig" %}
+    {% if not isPartsKitUrl %}
+        {{ include('_partials/footer.twig') }}
+    {% endif %}
 
 </body>
 </html>

--- a/templates/parts-kit/forms/select.twig
+++ b/templates/parts-kit/forms/select.twig
@@ -1,0 +1,83 @@
+{% extends 'viget-parts-kit/layout.twig' %}
+
+{% block main %}
+
+  {% set options = [
+    { label: 'Option 1', value: 'option-1' },
+    { label: 'Option 2', value: 'option-2' },
+    { label: 'Option 3', value: 'option-3' },
+  ] %}
+
+  {% set fields %}
+    <div class="flex flex-col gap-48 p-32 max-w-lg">
+      {{ include('_components/field-select.twig', {
+        id: 'custom-id',
+        label: 'Select',
+        subLabel: 'This is a sublabel',
+        instructions: 'This is an instruction',
+        options,
+        name: 'select',
+      }) }}
+
+      {{ include('_components/field-select.twig', {
+        label: 'Selected options',
+        options: [
+          { label: 'Option 1', value: 'option-1' },
+          { label: 'Option 2 (selected)', value: 'option-2', selected: true },
+          { label: 'Option 3', value: 'option-3' },
+        ],
+        name: 'select-selected',
+      }) }}
+
+      <form class="flex flex-col gap-16 items-start">
+        {{ include('_components/field-select.twig', {
+          class: 'w-full',
+          label: 'Select (required)',
+          required: true,
+          instructions: 'This is an instruction',
+          useEmptyOption: true,
+          placeholder: 'Choose an option',
+          options,
+          name: 'select-required',
+        }) }}
+
+        <button class="dark:text-white" type="submit">Test Validation</button>
+      </form>
+
+      {{ include('_components/field-select.twig', {
+        label: 'Select (required long)',
+        required: 'long',
+        instructions: 'This is an instruction',
+        options,
+        name: 'select-required-long',
+      }) }}
+
+      {{ include('_components/field-select.twig', {
+        label: 'Select (required with error)',
+        required: true,
+        instructions: 'This is an instruction',
+        errorMessages: ['This is an error message', 'This is another error message'],
+        options,
+        name: 'select-required-with-error',
+      }) }}
+
+      {{ include('_components/field-select.twig', {
+        label: 'Select (disabled)',
+        disabled: true,
+        options,
+        name: 'select-disabled',
+      }) }}
+    </div>
+  {% endset %}
+
+  {# default colors #}
+  {{ fields }}
+
+  {# dark background #}
+  <div class="bg-black dark">
+    {% namespace 'dark' %}
+      {{ fields }}
+    {% endnamespace %}
+  </div>
+
+{% endblock %}

--- a/templates/parts-kit/forms/text-input.twig
+++ b/templates/parts-kit/forms/text-input.twig
@@ -2,51 +2,63 @@
 
 {% block main %}
 
-  <div class="flex flex-col gap-48 p-32 max-w-lg">
-    {{ include('_components/field-text-input.twig', {
-      label: 'Text Input',
-      subLabel: 'This is a sublabel',
-      instructions: 'This is an instruction',
-    }) }}
-
-    {{ include('_components/field-text-input.twig', {
-      label: 'Text Input',
-      placeholder: 'Text Input (label hidden)',
-      labelHidden: true,
-      required: 'long',
-    }) }}
-
-    {{ include('_components/field-text-input.twig', {
-      label: 'Text Input (required)',
-      required: true,
-      instructions: 'This is an instruction',
-    }) }}
-
-    {{ include('_components/field-text-input.twig', {
-      label: 'Text Input (required long)',
-      required: 'long',
-      instructions: 'This is an instruction',
-    }) }}
-
-    {{ include('_components/field-text-input.twig', {
-      label: 'Text Input (required with error)',
-      required: true,
-      instructions: 'This is an instruction',
-      errorMessages: ['This is an error message', 'This is another error message'],
-    }) }}
-
-    {{ include('_components/field-text-input.twig', {
-      label: 'Text Input (disabled)',
-      disabled: true,
-    }) }}
-
-    {% set inputTypes = ['text', 'password', 'email', 'number', 'tel', 'url'] %}
-    {% for type in inputTypes %}
+  {% set fields %}
+    <div class="flex flex-col gap-48 p-32 max-w-lg">
       {{ include('_components/field-text-input.twig', {
-        label: 'Text Input (' ~ type ~ ')',
-        type,
+        label: 'Text Input',
+        subLabel: 'This is a sublabel',
+        instructions: 'This is an instruction',
       }) }}
-    {% endfor %}
+
+      {{ include('_components/field-text-input.twig', {
+        label: 'Text Input',
+        placeholder: 'Text Input (label hidden)',
+        labelHidden: true,
+        required: 'long',
+      }) }}
+
+      {{ include('_components/field-text-input.twig', {
+        label: 'Text Input (required)',
+        required: true,
+        instructions: 'This is an instruction',
+      }) }}
+
+      {{ include('_components/field-text-input.twig', {
+        label: 'Text Input (required long)',
+        required: 'long',
+        instructions: 'This is an instruction',
+      }) }}
+
+      {{ include('_components/field-text-input.twig', {
+        label: 'Text Input (required with error)',
+        required: true,
+        instructions: 'This is an instruction',
+        errorMessages: ['This is an error message', 'This is another error message'],
+      }) }}
+
+      {{ include('_components/field-text-input.twig', {
+        label: 'Text Input (disabled)',
+        disabled: true,
+      }) }}
+
+      {% set inputTypes = ['text', 'password', 'email', 'number', 'tel', 'url'] %}
+      {% for type in inputTypes %}
+        {{ include('_components/field-text-input.twig', {
+          label: 'Text Input (' ~ type ~ ')',
+          type,
+        }) }}
+      {% endfor %}
+    </div>
+  {% endset %}
+
+  {# default colors #}
+  {{ fields }}
+
+  {# dark background #}
+  <div class="bg-black dark">
+    {% namespace 'dark' %}
+      {{ fields }}
+    {% endnamespace %}
   </div>
 
 {% endblock %}

--- a/templates/parts-kit/forms/text-input.twig
+++ b/templates/parts-kit/forms/text-input.twig
@@ -5,9 +5,11 @@
   {% set fields %}
     <div class="flex flex-col gap-48 p-32 max-w-lg">
       {{ include('_components/field-text-input.twig', {
+        id: 'custom-id',
         label: 'Text Input',
         subLabel: 'This is a sublabel',
         instructions: 'This is an instruction',
+        name: 'text-input',
       }) }}
 
       {{ include('_components/field-text-input.twig', {
@@ -15,18 +17,26 @@
         placeholder: 'Placeholder (label hidden)',
         labelHidden: true,
         required: 'long',
+        name: 'text-input-placeholder',
       }) }}
 
-      {{ include('_components/field-text-input.twig', {
-        label: 'Text Input (required)',
-        required: true,
-        instructions: 'This is an instruction',
-      }) }}
+      <form class="flex flex-col gap-16 items-start">
+        {{ include('_components/field-text-input.twig', {
+          class: 'w-full',
+          label: 'Text Input (required)',
+          required: true,
+          instructions: 'This is an instruction',
+          name: 'text-input-required',
+        }) }}
+
+        <button type="submit">Test Validation</button>
+      </form>
 
       {{ include('_components/field-text-input.twig', {
         label: 'Text Input (required long)',
         required: 'long',
         instructions: 'This is an instruction',
+        name: 'text-input-required-long',
       }) }}
 
       {{ include('_components/field-text-input.twig', {
@@ -34,11 +44,13 @@
         required: true,
         instructions: 'This is an instruction',
         errorMessages: ['This is an error message', 'This is another error message'],
+        name: 'text-input-required-with-error',
       }) }}
 
       {{ include('_components/field-text-input.twig', {
         label: 'Text Input (disabled)',
         disabled: true,
+        name: 'text-input-disabled',
       }) }}
 
       {% set inputTypes = ['text', 'password', 'email', 'number', 'tel', 'url'] %}
@@ -46,6 +58,7 @@
         {{ include('_components/field-text-input.twig', {
           label: 'Text Input (' ~ type ~ ')',
           type,
+          name: 'text-input-' ~ type,
         }) }}
       {% endfor %}
     </div>

--- a/templates/parts-kit/forms/text-input.twig
+++ b/templates/parts-kit/forms/text-input.twig
@@ -29,7 +29,7 @@
           name: 'text-input-required',
         }) }}
 
-        <button type="submit">Test Validation</button>
+        <button class="dark:text-white" type="submit">Test Validation</button>
       </form>
 
       {{ include('_components/field-text-input.twig', {

--- a/templates/parts-kit/forms/text-input.twig
+++ b/templates/parts-kit/forms/text-input.twig
@@ -1,0 +1,52 @@
+{% extends 'viget-parts-kit/layout.twig' %}
+
+{% block main %}
+
+  <div class="flex flex-col gap-48 p-32 max-w-lg">
+    {{ include('_components/field-text-input.twig', {
+      label: 'Text Input',
+      subLabel: 'This is a sublabel',
+      instructions: 'This is an instruction',
+    }) }}
+
+    {{ include('_components/field-text-input.twig', {
+      label: 'Text Input',
+      placeholder: 'Text Input (label hidden)',
+      labelHidden: true,
+      required: 'long',
+    }) }}
+
+    {{ include('_components/field-text-input.twig', {
+      label: 'Text Input (required)',
+      required: true,
+      instructions: 'This is an instruction',
+    }) }}
+
+    {{ include('_components/field-text-input.twig', {
+      label: 'Text Input (required long)',
+      required: 'long',
+      instructions: 'This is an instruction',
+    }) }}
+
+    {{ include('_components/field-text-input.twig', {
+      label: 'Text Input (required with error)',
+      required: true,
+      instructions: 'This is an instruction',
+      errorMessages: ['This is an error message', 'This is another error message'],
+    }) }}
+
+    {{ include('_components/field-text-input.twig', {
+      label: 'Text Input (disabled)',
+      disabled: true,
+    }) }}
+
+    {% set inputTypes = ['text', 'password', 'email', 'number', 'tel', 'url'] %}
+    {% for type in inputTypes %}
+      {{ include('_components/field-text-input.twig', {
+        label: 'Text Input (' ~ type ~ ')',
+        type,
+      }) }}
+    {% endfor %}
+  </div>
+
+{% endblock %}

--- a/templates/parts-kit/forms/textarea.twig
+++ b/templates/parts-kit/forms/textarea.twig
@@ -29,7 +29,7 @@
           name: 'textarea-required',
         }) }}
 
-        <button type="submit">Test Validation</button>
+        <button class="dark:text-white" type="submit">Test Validation</button>
       </form>
 
       {{ include('_components/field-textarea.twig', {

--- a/templates/parts-kit/forms/textarea.twig
+++ b/templates/parts-kit/forms/textarea.twig
@@ -4,50 +4,52 @@
 
   {% set fields %}
     <div class="flex flex-col gap-48 p-32 max-w-lg">
-      {{ include('_components/field-text-input.twig', {
-        label: 'Text Input',
+      {{ include('_components/field-textarea.twig', {
+        label: 'Text Area',
         subLabel: 'This is a sublabel',
         instructions: 'This is an instruction',
       }) }}
 
-      {{ include('_components/field-text-input.twig', {
-        label: 'Text Input',
+      {{ include('_components/field-textarea.twig', {
+        label: 'Text Area',
         placeholder: 'Placeholder (label hidden)',
         labelHidden: true,
         required: 'long',
       }) }}
 
-      {{ include('_components/field-text-input.twig', {
-        label: 'Text Input (required)',
+      {{ include('_components/field-textarea.twig', {
+        label: 'Text Area (required)',
         required: true,
         instructions: 'This is an instruction',
       }) }}
 
-      {{ include('_components/field-text-input.twig', {
-        label: 'Text Input (required long)',
+      {{ include('_components/field-textarea.twig', {
+        label: 'Text Area (required long)',
         required: 'long',
         instructions: 'This is an instruction',
       }) }}
 
-      {{ include('_components/field-text-input.twig', {
-        label: 'Text Input (required with error)',
+      {{ include('_components/field-textarea.twig', {
+        label: 'Text Area (required with error)',
         required: true,
         instructions: 'This is an instruction',
         errorMessages: ['This is an error message', 'This is another error message'],
       }) }}
 
-      {{ include('_components/field-text-input.twig', {
-        label: 'Text Input (disabled)',
+      {{ include('_components/field-textarea.twig', {
+        label: 'Text Area (disabled)',
         disabled: true,
       }) }}
 
-      {% set inputTypes = ['text', 'password', 'email', 'number', 'tel', 'url'] %}
-      {% for type in inputTypes %}
-        {{ include('_components/field-text-input.twig', {
-          label: 'Text Input (' ~ type ~ ')',
-          type,
-        }) }}
-      {% endfor %}
+      {{ include('_components/field-textarea.twig', {
+        label: 'Text Area (custom rows)',
+        rows: 10,
+      }) }}
+
+      {{ include('_components/field-textarea.twig', {
+        label: 'Text Area (resize)',
+        resize: true,
+      }) }}
     </div>
   {% endset %}
 

--- a/templates/parts-kit/forms/textarea.twig
+++ b/templates/parts-kit/forms/textarea.twig
@@ -5,9 +5,11 @@
   {% set fields %}
     <div class="flex flex-col gap-48 p-32 max-w-lg">
       {{ include('_components/field-textarea.twig', {
+        id: 'custom-id',
         label: 'Text Area',
         subLabel: 'This is a sublabel',
         instructions: 'This is an instruction',
+        name: 'textarea',
       }) }}
 
       {{ include('_components/field-textarea.twig', {
@@ -15,18 +17,26 @@
         placeholder: 'Placeholder (label hidden)',
         labelHidden: true,
         required: 'long',
+        name: 'textarea-placeholder',
       }) }}
 
-      {{ include('_components/field-textarea.twig', {
-        label: 'Text Area (required)',
-        required: true,
-        instructions: 'This is an instruction',
-      }) }}
+      <form class="flex flex-col gap-16 items-start">
+        {{ include('_components/field-textarea.twig', {
+          class: 'w-full',
+          label: 'Text Area (required)',
+          required: true,
+          instructions: 'This is an instruction',
+          name: 'textarea-required',
+        }) }}
+
+        <button type="submit">Test Validation</button>
+      </form>
 
       {{ include('_components/field-textarea.twig', {
         label: 'Text Area (required long)',
         required: 'long',
         instructions: 'This is an instruction',
+        name: 'textarea-required-long',
       }) }}
 
       {{ include('_components/field-textarea.twig', {
@@ -34,21 +44,25 @@
         required: true,
         instructions: 'This is an instruction',
         errorMessages: ['This is an error message', 'This is another error message'],
+        name: 'textarea-required-with-error',
       }) }}
 
       {{ include('_components/field-textarea.twig', {
         label: 'Text Area (disabled)',
         disabled: true,
+        name: 'textarea-disabled',
       }) }}
 
       {{ include('_components/field-textarea.twig', {
         label: 'Text Area (custom rows)',
         rows: 10,
+        name: 'textarea-custom-rows',
       }) }}
 
       {{ include('_components/field-textarea.twig', {
         label: 'Text Area (resize)',
         resize: true,
+        name: 'textarea-resize',
       }) }}
     </div>
   {% endset %}


### PR DESCRIPTION
### Overview

- #52

- Implements all of the items under ["Forms" in Blueprint](https://staging.blueprint.viget.com/forms/field-group/).
    - Adds a custom TW plugin for form inputs.
    - Turns on the `selector` strategy for dark mode (used to be [called class](https://tailwindcss.com/docs/dark-mode#:~:text=The%20selector%20strategy%20replaced%20the%20class%20strategy%20in%20Tailwind%20CSS%20v3.4.1.)). This is how we typically style components to work with dark backgrounds. Although it prevents us from doing a true light/dark mode across the entire site.

## Screenshots

### Text Input

![CleanShot 2025-01-03 at 09 02 20@2x](https://github.com/user-attachments/assets/3c1a3d9d-9c90-40d9-a6bb-6886eceb840d)

### Textarea
![CleanShot 2025-01-03 at 09 02 57@2x](https://github.com/user-attachments/assets/9f39b3df-f365-4af7-b4d3-cb3fc33d55ff)

### Select
![CleanShot 2025-01-03 at 09 03 20@2x](https://github.com/user-attachments/assets/ddb9ec9a-36fd-44f5-857e-61c1e2b41464)


