### PR TITLE
[#57] Pagination component

### DIFF
--- a/config/tailwind/buttons.js
+++ b/config/tailwind/buttons.js
@@ -4,7 +4,7 @@ export default plugin(({ addComponents }) => {
   // Base Styles
   const base = {
     // core
-    '@apply inline-flex items-center rounded font-bold transition text-base gap-12 cursor-pointer no-underline':
+    '@apply inline-flex items-center justify-center rounded font-bold transition text-base gap-12 cursor-pointer no-underline':
       {},
     // focus
     '@apply focus:outline-none focus-visible:ring-4': {},
@@ -100,6 +100,11 @@ export default plugin(({ addComponents }) => {
       fontSize: '0 !important',
       lineHeight: '0 !important',
       '@apply !p-0 !gap-0 aspect-square justify-center items-center': {},
+    },
+
+    // Coerce a button to be square
+    '.btn-square': {
+      '@apply aspect-square p-0': {},
     },
   }
 

--- a/config/tailwind/buttons.js
+++ b/config/tailwind/buttons.js
@@ -101,11 +101,6 @@ export default plugin(({ addComponents }) => {
       lineHeight: '0 !important',
       '@apply !p-0 !gap-0 aspect-square justify-center items-center': {},
     },
-
-    // Coerce a button to be square
-    '.btn-square': {
-      '@apply aspect-square p-0': {},
-    },
   }
 
   addComponents(buttons)

--- a/templates/_components/button.twig
+++ b/templates/_components/button.twig
@@ -15,6 +15,9 @@
 {# @var string|null icon The name of the icon to use #}
 {% set icon = icon ?? null %}
 
+{# @var bool iconLast #}
+{% set iconLast = iconLast ?? false %}
+
 {# @var boolean iconOnly #}
 {% set iconOnly = iconOnly ?? false %}
 
@@ -62,6 +65,7 @@
   {{ icon ? icon({
     name: icon,
     size: size,
+    class: iconLast ? 'order-last' : null,
   }) }}
 
   {{ text }}

--- a/templates/_components/pagination.twig
+++ b/templates/_components/pagination.twig
@@ -1,0 +1,106 @@
+{# @var string|null nextUrl #}
+{% set nextUrl = nextUrl ?? null %}
+
+{# @var string|null prevUrl #}
+{% set prevUrl = prevUrl ?? null %}
+
+{# @var int currentPage #}
+{% set currentPage = currentPage %}
+
+{# @var int totalPages #}
+{% set totalPages = totalPages %}
+
+{# @var string|null firstUrl #}
+{% set firstUrl = firstUrl ?? null %}
+
+{# @var string|null lastUrl #}
+{% set lastUrl = lastUrl ?? null %}
+
+{# @var array visibleUrls #}
+{% set visibleUrls = visibleUrls ?? [] %}
+
+{# @var string size #}
+{% set size = size ?? 'md' %}
+
+{% set ariaLabel = ariaLabel ?? 'pagination navigation' %}
+
+{% macro paginationItem(props = {}) %}
+  {% set url = props.url ?? null %}
+  {% set page = props.page ?? null %}
+  {% set size = props.size ?? null %}
+  {% set currentPage = props.currentPage ?? null %}
+
+  {{ include('_components/button.twig', {
+      href: url,
+      text: page,
+      variant: page == currentPage ? 'contained' : 'subtle',
+      size: size,
+      class: cx('!p-0 aspect-square rounded-full'),
+      attrs: {
+        'aria-current': page == currentPage ? 'page' : null,
+      },
+    }) }}
+{% endmacro %}
+
+<nav
+  aria-label="{{ ariaLabel }}"
+  class="text-sky-600 dark:text-white"
+>
+  <ul class="flex items-center gap-16">
+    <li>
+      {{ include('_components/button.twig', {
+        href: prevUrl,
+        text: 'Previous',
+        icon: 'arrow-left',
+        variant: 'outlined',
+        size,
+        currentPage,
+      }) }}
+    </li>
+
+    {% if visibleUrls[1] is not defined %}
+      <li>
+        {{ _self.paginationItem({
+          url: firstUrl,
+          page: 1,
+          size,
+          currentPage,
+        }) }}
+      </li>
+      <li aria-hidden="true">...</li>
+    {% endif %}
+
+    {% for page, url in visibleUrls %}
+      <li>
+        {{ _self.paginationItem({
+          url: url,
+          page: page,
+          size,
+          currentPage,
+        }) }}
+      </li>
+    {% endfor %}
+
+    {% if visibleUrls[totalPages] is not defined %}
+      <li aria-hidden="true">...</li>
+      <li>
+        {{ _self.paginationItem({
+          url: lastUrl,
+          page: totalPages,
+          size: size,
+        }) }}
+      </li>
+    {% endif %}
+
+    <li>
+      {{ include('_components/button.twig', {
+        href: nextUrl,
+        text: 'Next',
+        icon: 'arrow-right',
+        variant: 'outlined',
+        size: size,
+        iconLast: true,
+      }) }}
+    </li>
+  </ul>
+</nav>

--- a/templates/_components/pagination.twig
+++ b/templates/_components/pagination.twig
@@ -1,28 +1,59 @@
+{# @var object pageInfo - Pass the pageInfo object from Craft's {% paginate %} tag to pre-fill all props #}
+{% set pageInfo = pageInfo ?? null %}
+
+{#
+   @var int maxLinks
+   Controls the number of page links to show. Includes the first and last page URLs.
+   Odd numbers work best.
+
+   maxLinks has no effect when using manual props
+#}
+{% set maxLinks = maxLinks ?? 5 %}
+
 {# @var string|null nextUrl #}
-{% set nextUrl = nextUrl ?? null %}
+{% set nextUrl = nextUrl ?? pageInfo.nextUrl ?? null %}
 
 {# @var string|null prevUrl #}
-{% set prevUrl = prevUrl ?? null %}
+{% set prevUrl = prevUrl ?? pageInfo.prevUrl ?? null %}
 
 {# @var int currentPage #}
-{% set currentPage = currentPage %}
+{% set currentPage = currentPage ?? pageInfo.currentPage ?? null %}
 
 {# @var int totalPages #}
-{% set totalPages = totalPages %}
+{% set totalPages = totalPages ?? pageInfo.totalPages ?? null %}
 
 {# @var string|null firstUrl #}
-{% set firstUrl = firstUrl ?? null %}
+{% set firstUrl = firstUrl ?? pageInfo.firstUrl ?? null %}
 
 {# @var string|null lastUrl #}
-{% set lastUrl = lastUrl ?? null %}
+{% set lastUrl = lastUrl ?? pageInfo.lastUrl ?? null %}
 
-{# @var array visibleUrls #}
+{# @var array visibleUrls An array of visible page URLs indexed by page number #}
 {% set visibleUrls = visibleUrls ?? [] %}
 
 {# @var string size #}
 {% set size = size ?? 'md' %}
 
+{# @var string ariaLabel #}
 {% set ariaLabel = ariaLabel ?? 'pagination navigation' %}
+
+{# Computed values #}
+{% set needEllipsis = totalPages > maxLinks %}
+{% set elipsisThreshold = floor(maxLinks / 2) %}
+{% set hasStartEllipsis = needEllipsis and currentPage > maxLinks - elipsisThreshold %}
+{% set hasEndEllipsis = needEllipsis and currentPage < totalPages - elipsisThreshold %}
+
+{% if pageInfo %}
+  {% if hasStartEllipsis %}
+    {% set maxLinks = maxLinks - 1 %}
+  {% endif  %}
+
+  {% if hasEndEllipsis or (currentPage < totalPages - (elipsisThreshold - 1)) %}
+    {% set maxLinks = maxLinks - 1 %}
+  {% endif %}
+
+  {% set visibleUrls = pageInfo.getDynamicRangeUrls(maxLinks) %}
+{% endif %}
 
 {% macro paginationItem(props = {}) %}
   {% set url = props.url ?? null %}
@@ -67,7 +98,10 @@
           currentPage,
         }) }}
       </li>
-      <li aria-hidden="true">...</li>
+      {# Hide elipsis if page 2 is in the visibleUrls array #}
+      {% if hasStartEllipsis %}
+        <li aria-hidden="true">...</li>
+      {% endif %}
     {% endif %}
 
     {% for page, url in visibleUrls %}
@@ -82,7 +116,10 @@
     {% endfor %}
 
     {% if visibleUrls[totalPages] is not defined %}
-      <li aria-hidden="true">...</li>
+      {# Hide elipsis if page totalPages - 1 is in the visibleUrls array #}
+      {% if hasEndEllipsis %}
+        <li aria-hidden="true">...</li>
+      {% endif %}
       <li>
         {{ _self.paginationItem({
           url: lastUrl,

--- a/templates/parts-kit/button/default.twig
+++ b/templates/parts-kit/button/default.twig
@@ -54,6 +54,14 @@
           text: 'Button',
           size,
           icon: 'arrow-right',
+          iconLast: true,
+        }) }}
+
+        {{ include('_components/button.twig', {
+          variant: 'contained',
+          text: 'Button',
+          size,
+          icon: 'arrow-right',
           iconOnly: true,
         }) }}
 

--- a/templates/parts-kit/paginaton/default.twig
+++ b/templates/parts-kit/paginaton/default.twig
@@ -1,0 +1,70 @@
+{% extends 'viget-parts-kit/layout.twig' %}
+
+{#
+
+The pagination component is designed to work well with Craft's pagination features
+
+https://craftcms.com/docs/5.x/development/element-queries.html#pagination
+
+However, if you need to manually building up props for the component is relatively easy.
+
+Example:
+
+  {% set blogQuery = craft.entries()
+      .section('blog')
+      .limit(2)
+      .orderBy('postDate DESC') %}
+
+  Paginate the query into a `posts` variable:
+  {% paginate blogQuery as pageInfo, posts %}
+
+
+  {{ include('_components/pagination.twig', {
+    ...pageInfo,
+    visibleUrls: pageInfo.getDynamicRangeUrls(5),
+  }) }}
+
+#}
+
+{% set props = {
+  nextUrl: '#5',
+  prevUrl: '#3',
+  firstUrl: '#1',
+  lastUrl: '#15',
+  totalPages: 15,
+  currentPage: 4,
+  visibleUrls: {
+    2: '#2',
+    3: '#3',
+    4: '#4',
+    5: '#5',
+    6: '#6',
+  },
+} %}
+
+{% set examples %}
+  {{ include('_components/pagination.twig', {
+    ...props,
+    size: 'sm',
+  }) }}
+
+  {{ include('_components/pagination.twig', {
+    ...props,
+    size: 'md',
+  }) }}
+
+  {{ include('_components/pagination.twig', {
+    ...props,
+    size: 'lg',
+  }) }}
+{% endset %}
+
+{% block main %}
+  <div class="p-64 flex flex-col gap-48">
+    {{ examples }}
+  </div>
+
+  <div class="dark bg-black p-64 flex flex-col gap-48">
+    {{ examples }}
+  </div>
+{% endblock %}

--- a/templates/parts-kit/paginaton/default.twig
+++ b/templates/parts-kit/paginaton/default.twig
@@ -1,44 +1,47 @@
 {% extends 'viget-parts-kit/layout.twig' %}
 
 {#
-
-The pagination component is designed to work well with Craft's pagination features
+The pagination component that integrates well with Craft's {% paginate %} by
+using the pageInfo object.
 
 https://craftcms.com/docs/5.x/development/element-queries.html#pagination
 
-However, if you need to manually building up props for the component is relatively easy.
+You can manually use this component by passing props, however, calculating
+the number of links to show must be implemented manually.
 
-Example:
+Example Usage:
 
   {% set blogQuery = craft.entries()
-      .section('blog')
-      .limit(2)
-      .orderBy('postDate DESC') %}
+    .section('blog')
+    .limit(1)
+    .orderBy('postDate DESC') %}
 
-  Paginate the query into a `posts` variable:
   {% paginate blogQuery as pageInfo, posts %}
 
+  {% for post in posts %}
+    <article>
+      <h2>{{ post.title }}</h2>
+    </article>
+  {% endfor %}
 
   {{ include('_components/pagination.twig', {
-    ...pageInfo,
-    visibleUrls: pageInfo.getDynamicRangeUrls(5),
+    pageInfo,
+    maxLinks: 7,
   }) }}
 
 #}
 
 {% set props = {
-  nextUrl: '#5',
-  prevUrl: '#3',
-  firstUrl: '#1',
-  lastUrl: '#15',
+  nextUrl: '?page=5',
+  prevUrl: '?page=3',
+  firstUrl: '?page=1',
+  lastUrl: '?page=15',
   totalPages: 15,
-  currentPage: 4,
+  currentPage: 5,
   visibleUrls: {
-    2: '#2',
-    3: '#3',
-    4: '#4',
-    5: '#5',
-    6: '#6',
+    4: '?page=4',
+    5: '?page=5',
+    6: '?page=6',
   },
 } %}
 


### PR DESCRIPTION
## This Change

- #57 

Added `_components/pagination.twig` component that is modeled after Blueprint. 

Craft CMS offers a `{% paginate %}` tag that does most of the heavy lifting for creating links. 


## Screenshots

### **Parts Kit** Showing size & dark variants. 

<img width="1233" alt="CleanShot 2025-02-06 at 15 36 53@2x" src="https://github.com/user-attachments/assets/c3c40760-938f-4b61-99d3-42cad9a8249b" />

### **Craft {% paginate %} demo - Using 5 and 7 max links.**


https://github.com/user-attachments/assets/2e53272a-e901-4ad6-82bd-6f44512ea603


https://github.com/user-attachments/assets/8223629c-8886-4b9f-8f61-68df47055c1d


