### PR TITLE
[#67] Add global fields to put scripts in head, body, footer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "nystudio107/craft-vite": "5.0.1",
     "spacecatninja/imager-x": "5.1.0",
     "spacecatninja/imager-x-power-pack": "1.0.5",
+    "verbb/expanded-singles": "3.0.1",
     "verbb/navigation": "3.0.5",
     "viget/craft-classnames": "3.0.0",
     "viget/craft-parts-kit": "dev-main",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "34338e9ad842dafdc77b8b50ac722dca",
+    "content-hash": "1b83de54c845dfa1a12cbbb1aa5f849e",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -6292,6 +6292,60 @@
             "time": "2024-11-13T00:08:07+00:00"
         },
         {
+            "name": "verbb/expanded-singles",
+            "version": "3.0.1",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/verbb/expanded-singles/zipball/7cd2d1c41344bb0ebacecb5d1e96a493649f6822",
+                "reference": "7cd2d1c41344bb0ebacecb5d1e96a493649f6822",
+                "shasum": ""
+            },
+            "require": {
+                "craftcms/cms": "^5.0.0",
+                "php": "^8.2",
+                "verbb/base": "^3.0.0"
+            },
+            "type": "craft-plugin",
+            "extra": {
+                "name": "Expanded Singles",
+                "handle": "expanded-singles",
+                "description": "Alters the Entries Index sidebar to list all Singles, rather than grouping them under a 'Singles' link.",
+                "documentationUrl": "https://github.com/verbb/expanded-singles",
+                "changelogUrl": "https://raw.githubusercontent.com/verbb/expanded-singles/craft-5/CHANGELOG.md",
+                "class": "verbb\\expandedsingles\\ExpandedSingles"
+            },
+            "autoload": {
+                "psr-4": {
+                    "verbb\\expandedsingles\\": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Verbb",
+                    "homepage": "https://verbb.io"
+                }
+            ],
+            "description": "Extract Single entries to be top-level entries.",
+            "keywords": [
+                "cms",
+                "craft",
+                "craft-plugin",
+                "craftcms",
+                "expanded singles"
+            ],
+            "support": {
+                "email": "support@verbb.io",
+                "issues": "https://github.com/verbb/expanded-singles/issues?state=open",
+                "source": "https://github.com/verbb/expanded-singles",
+                "docs": "https://github.com/verbb/expanded-singles",
+                "rss": "https://github.com/verbb/expanded-singles/commits/v2.atom"
+            },
+            "time": "2024-10-20T02:02:19+00:00"
+        },
+        {
             "name": "verbb/navigation",
             "version": "3.0.5",
             "dist": {
@@ -8060,14 +8114,14 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "viget/craft-parts-kit": 20,
         "craftcms/ecs": 20,
-        "craftcms/phpstan": 20
+        "craftcms/phpstan": 20,
+        "viget/craft-parts-kit": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2"
     },

--- a/config/project/entryTypes/globalCode--679826d7-4cc2-4833-876c-f3d295ff3680.yaml
+++ b/config/project/entryTypes/globalCode--679826d7-4cc2-4833-876c-f3d295ff3680.yaml
@@ -1,0 +1,78 @@
+color: null
+fieldLayouts:
+  265dea68-83f5-4ec6-955f-e4a6dea24878:
+    tabs:
+      -
+        elementCondition: null
+        elements:
+          -
+            dateAdded: '2025-02-21T14:59:23+00:00'
+            dismissible: false
+            elementCondition: null
+            style: warning
+            tip: "**Use Caution**: Improperly formatted code can break pages.\r\n\r\nBe sure to wrap any JavaScript in opening and closing tags. \r\n\r\n\r\n    <script>  \r\n        // Your Code Here  \r\n    </script>\r\n\r\nUnless a script needs to load before any other content on the site, it is better for performance to place scripts in the **Bottom of <body> Scripts & Code** field. "
+            type: craft\fieldlayoutelements\Tip
+            uid: ec57e586-f79e-4233-83da-ea2632faa1ca
+            userCondition: null
+          -
+            dateAdded: '2025-02-21T14:59:23+00:00'
+            elementCondition: null
+            fieldUid: 1b822704-0a4e-42df-9036-3d82a218bc98 # Code
+            handle: head
+            includeInCards: false
+            instructions: 'This code will be inserted into the `<head>` tag on every page.'
+            label: '<head> Scripts & Code'
+            providesThumbs: false
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: d2865248-db3e-45a4-b65a-8dd40fdafabd
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            dateAdded: '2025-02-21T14:59:23+00:00'
+            elementCondition: null
+            fieldUid: 1b822704-0a4e-42df-9036-3d82a218bc98 # Code
+            handle: bodyTop
+            includeInCards: false
+            instructions: 'This code will be inserted right after the opening `<body>` tag on every page.'
+            label: 'Top of <body> Scripts & Code'
+            providesThumbs: false
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 0d070f90-058f-4e8d-aba0-eb35772ea3c9
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            dateAdded: '2025-02-21T14:59:23+00:00'
+            elementCondition: null
+            fieldUid: 1b822704-0a4e-42df-9036-3d82a218bc98 # Code
+            handle: bodyBottom
+            includeInCards: false
+            instructions: 'This code will be inserted right at the very end of your page before the closing `</body>` tag on every page.'
+            label: 'Bottom of <body> Scripts & Code'
+            providesThumbs: false
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 894ba237-3a40-4426-b0cb-db2c9010788b
+            userCondition: null
+            warning: null
+            width: 100
+        name: Content
+        uid: 8ea525da-89e8-4bc6-86c1-7dfcfe451b59
+        userCondition: null
+handle: globalCode
+hasTitleField: false
+icon: code
+name: 'Global Code'
+showSlugField: false
+showStatusField: false
+slugTranslationKeyFormat: null
+slugTranslationMethod: site
+titleFormat: null
+titleTranslationKeyFormat: null
+titleTranslationMethod: site

--- a/config/project/fields/bodyBottom--1b822704-0a4e-42df-9036-3d82a218bc98.yaml
+++ b/config/project/fields/bodyBottom--1b822704-0a4e-42df-9036-3d82a218bc98.yaml
@@ -1,0 +1,16 @@
+columnSuffix: null
+handle: bodyBottom
+instructions: null
+name: Code
+searchable: false
+settings:
+  byteLimit: null
+  charLimit: null
+  code: true
+  initialRows: 4
+  multiline: true
+  placeholder: null
+  uiMode: normal
+translationKeyFormat: null
+translationMethod: none
+type: craft\fields\PlainText

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1735926433
+dateModified: 1740150714
 email:
   fromEmail: $SYSTEM_EMAIL_FROM
   fromName: 'Viget Craft Starter'
@@ -72,6 +72,13 @@ plugins:
     edition: standard
     enabled: true
     schemaVersion: 1.0.0
+  expanded-singles:
+    edition: standard
+    enabled: true
+    schemaVersion: 1.0.0
+    settings:
+      expandSingles: true
+      redirectToEntry: true
   imager-x:
     edition: lite
     enabled: true

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -1,4 +1,32 @@
 dateModified: 1740150714
+elementSources:
+  craft\elements\Entry:
+    -
+      defaultSort:
+        - postDate
+        - desc
+      defaultViewMode: ''
+      disabled: false
+      key: '*'
+      tableAttributes:
+        - status
+        - section
+        - postDate
+        - expiryDate
+        - link
+      type: native
+    -
+      heading: Singles
+      type: heading
+    -
+      key: 'single:969acdd6-6362-41b1-b782-6bbd43a8a6b4' # Home
+      type: native
+    -
+      heading: Globals
+      type: heading
+    -
+      key: 'single:173e4191-a638-4ddb-a638-d99fae5e0630' # Global Code
+      type: native
 email:
   fromEmail: $SYSTEM_EMAIL_FROM
   fromName: 'Viget Craft Starter'
@@ -22,6 +50,7 @@ fs:
 meta:
   __names__:
     0e7762a5-2553-4c0d-b8af-9b43b59524bf: Home # Home
+    1b822704-0a4e-42df-9036-3d82a218bc98: Code # Code
     2ea51656-9b0c-4736-a6fe-c95dc805dc60: Button # Button
     3bcf7ddb-71e7-4115-868c-815b3611b34c: 'Text With Media' # Text With Media
     3f1dc0c5-f091-469a-858a-4cbd3596bab7: 'Icon Card' # Icon Card
@@ -35,12 +64,14 @@ meta:
     55cc26b6-8b49-47de-bbe7-5908da6f4545: 'Video Url' # Video Url
     69fe4c18-21c9-4a3d-8fce-9988d3f741e4: Link # Link
     101b4db6-8914-45eb-a661-180b15f70894: 'Footer Navigation' # Footer Navigation
+    173e4191-a638-4ddb-a638-d99fae5e0630: 'Global Code' # Global Code
     534ccdd8-7abd-4300-a102-71885b21c126: 'Call To Action' # Call To Action
     570fb481-ad97-46db-8bad-f7b0fd90e831: Image # Image
     805d8826-faed-4186-9b88-f509eb9b07e6: 'Viget Craft Starter' # Viget Craft Starter
     896b8f2a-ed0c-42c9-b5fd-ba8668fc6784: 'Rich Text' # Rich Text
     969acdd6-6362-41b1-b782-6bbd43a8a6b4: Home # Home
     4382f55f-01a1-4b67-84c8-ebbc89b238d2: Heading # Heading
+    679826d7-4cc2-4833-876c-f3d295ff3680: 'Global Code' # Global Code
     853413e4-e02c-487e-81a5-04e58eb18683: Assets # Assets
     a99edea2-f8ae-44e5-a12f-89cb9aa66738: Description # Description
     ac3b0590-d417-429e-aa1f-96be3c79a5b0: 'Media Type' # Media Type

--- a/config/project/sections/globalCode--173e4191-a638-4ddb-a638-d99fae5e0630.yaml
+++ b/config/project/sections/globalCode--173e4191-a638-4ddb-a638-d99fae5e0630.yaml
@@ -1,0 +1,15 @@
+defaultPlacement: end
+enableVersioning: true
+entryTypes:
+  - 679826d7-4cc2-4833-876c-f3d295ff3680 # Global Code
+handle: globalCode
+maxAuthors: 1
+name: 'Global Code'
+propagationMethod: all
+siteSettings:
+  35b563a0-4662-40b9-b885-a8450a2868d9: # Viget Craft Starter
+    enabledByDefault: true
+    hasUrls: false
+    template: null
+    uriFormat: null
+type: single

--- a/templates/_layouts/base.twig
+++ b/templates/_layouts/base.twig
@@ -23,10 +23,12 @@
     {# Hide elements if we're in the parts-kit #}
     {% set isPartsKitUrl = craft.app.request.segments | first == 'parts-kit' %}
 
+    {# -- Dangerously adds raw HTML -- #}
     {{ globalCode.head|raw }}
 </head>
 <body>
 
+    {# -- Dangerously adds raw HTML -- #}
     {{ globalCode.bodyTop|raw }}
 
     {% if not isPartsKitUrl %}
@@ -41,6 +43,7 @@
         {{ include('_partials/footer.twig') }}
     {% endif %}
 
+    {# -- Dangerously adds raw HTML -- #}
     {{ globalCode.bodyBottom|raw }}
 
 </body>

--- a/templates/_layouts/base.twig
+++ b/templates/_layouts/base.twig
@@ -1,3 +1,4 @@
+{%- set globalCode = craft.entries.section('globalCode').one() -%}
 <!DOCTYPE html>
 <html dir="auto" lang="en">
 <head>
@@ -21,8 +22,12 @@
 
     {# Hide elements if we're in the parts-kit #}
     {% set isPartsKitUrl = craft.app.request.segments | first == 'parts-kit' %}
+
+    {{ globalCode.head|raw }}
 </head>
 <body>
+
+    {{ globalCode.bodyTop|raw }}
 
     {% if not isPartsKitUrl %}
         {{ include('_partials/header.twig') }}
@@ -35,6 +40,8 @@
     {% if not isPartsKitUrl %}
         {{ include('_partials/footer.twig') }}
     {% endif %}
+
+    {{ globalCode.bodyBottom|raw }}
 
 </body>
 </html>


### PR DESCRIPTION
### Overview
- #67

Adds global scripts as a Craft Single. 

[Also adds Verbb Expanded singles. ](https://verbb.io/craft-plugins/expanded-singles/features) 

### Entries Screen

### Craft Admin
![CleanShot 2025-02-21 at 07 12 01@2x](https://github.com/user-attachments/assets/f3842edf-5188-4d33-a79b-234f7d5946da)


### Frontend
![CleanShot 2025-02-21 at 07 12 19@2x](https://github.com/user-attachments/assets/6c9f4d0c-9902-4766-b793-5a1d48f48197)
