### PR TITLE
[#67] Global Scripts (Using Matrix Blocks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ replacing standard plugins with similar alternatives (unless absolutely necessar
 | [Retour](https://plugins.craftcms.com/retour)                     | `nystudio107/craft-retour`        | Provides an Craft admin UI to set up redirects. Will automatically create redirects when URLs of entries change.                                                                    | $59.00       | $29.00        |
 | [SEOMatic](https://plugins.craftcms.com/seomatic)                 | `nystudio107/craft-seomatic`      | A turnkey SEO plugin that follows [modern SEO best practices](https://nystudio107.com/blog/modern-seo-snake-oil-vs-substance).                                                      | $99.00       | $49.00        |
 | [Vite](https://plugins.craftcms.com/vite)                         | `nystudio107/craft-vite`          | Loads front-end files that are compiled by Vite.                                                                                                                                    | Free         | Free          |
+| [Expanded Singles](https://plugins.craftcms.com/expanded-singles) | `verbb/expanded-singles`          | Change the entries index sidebar to list all singles, rather than grouping them under a 'Singles' menu item.                                                                        | Free         | Free          |
 
 # Contribute to this starter
 

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "nystudio107/craft-vite": "5.0.1",
     "spacecatninja/imager-x": "5.1.1",
     "spacecatninja/imager-x-power-pack": "1.0.5",
+    "verbb/expanded-singles": "3.0.2",
     "verbb/navigation": "3.0.6",
     "viget/craft-classnames": "3.0.0",
     "viget/craft-parts-kit": "dev-main",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87c28e5ebafa5425c4806a62f5d7d896",
+    "content-hash": "79a7ee6dc518c8ef59c92553864e47f2",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -6496,6 +6496,60 @@
             "time": "2024-11-13T00:08:07+00:00"
         },
         {
+            "name": "verbb/expanded-singles",
+            "version": "3.0.2",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/verbb/expanded-singles/zipball/ed6770025b03af081ef6246dfafeee864a727ef1",
+                "reference": "ed6770025b03af081ef6246dfafeee864a727ef1",
+                "shasum": ""
+            },
+            "require": {
+                "craftcms/cms": "^5.0.0",
+                "php": "^8.2",
+                "verbb/base": "^3.0.0"
+            },
+            "type": "craft-plugin",
+            "extra": {
+                "name": "Expanded Singles",
+                "handle": "expanded-singles",
+                "description": "Alters the Entries Index sidebar to list all Singles, rather than grouping them under a 'Singles' link.",
+                "documentationUrl": "https://github.com/verbb/expanded-singles",
+                "changelogUrl": "https://raw.githubusercontent.com/verbb/expanded-singles/craft-5/CHANGELOG.md",
+                "class": "verbb\\expandedsingles\\ExpandedSingles"
+            },
+            "autoload": {
+                "psr-4": {
+                    "verbb\\expandedsingles\\": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Verbb",
+                    "homepage": "https://verbb.io"
+                }
+            ],
+            "description": "Extract Single entries to be top-level entries.",
+            "keywords": [
+                "cms",
+                "craft",
+                "craft-plugin",
+                "craftcms",
+                "expanded singles"
+            ],
+            "support": {
+                "email": "support@verbb.io",
+                "issues": "https://github.com/verbb/expanded-singles/issues?state=open",
+                "source": "https://github.com/verbb/expanded-singles",
+                "docs": "https://github.com/verbb/expanded-singles",
+                "rss": "https://github.com/verbb/expanded-singles/commits/v2.atom"
+            },
+            "time": "2025-03-04T23:14:53+00:00"
+        },
+        {
             "name": "verbb/navigation",
             "version": "3.0.6",
             "dist": {
@@ -8295,14 +8349,14 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "viget/craft-parts-kit": 20,
         "craftcms/ecs": 20,
-        "craftcms/phpstan": 20
+        "craftcms/phpstan": 20,
+        "viget/craft-parts-kit": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.2"
     },

--- a/config/project/entryTypes/codeBlock--cbf3aeac-588c-4aeb-9573-6f1920206abf.yaml
+++ b/config/project/entryTypes/codeBlock--cbf3aeac-588c-4aeb-9573-6f1920206abf.yaml
@@ -22,6 +22,22 @@ fieldLayouts:
             warning: null
             width: 100
           -
+            dateAdded: '2025-03-10T17:28:48+00:00'
+            elementCondition: null
+            fieldUid: a99edea2-f8ae-44e5-a12f-89cb9aa66738 # Description
+            handle: null
+            includeInCards: false
+            instructions: null
+            label: null
+            providesThumbs: false
+            required: false
+            tip: "Add a brief description of your code block. \r\n\r\nThis will never appear on the front end of the site. "
+            type: craft\fieldlayoutelements\CustomField
+            uid: 1b062515-de1a-4a90-b9e7-368032fe47e7
+            userCondition: null
+            warning: null
+            width: 100
+          -
             dateAdded: '2025-03-10T16:44:51+00:00'
             elementCondition: null
             fieldUid: 7a701601-ee6c-4d56-8bd0-efa7719f6a67 # Code
@@ -35,7 +51,7 @@ fieldLayouts:
             type: craft\fieldlayoutelements\CustomField
             uid: 9848de68-0b9e-4a27-a38c-34a7f68eeaba
             userCondition: null
-            warning: null
+            warning: 'Use Caution: Improperly formatted code can break pages.'
             width: 100
         name: Content
         uid: 39937348-1f3d-4fa6-aaf3-cffe7a6c2a13

--- a/config/project/entryTypes/codeBlock--cbf3aeac-588c-4aeb-9573-6f1920206abf.yaml
+++ b/config/project/entryTypes/codeBlock--cbf3aeac-588c-4aeb-9573-6f1920206abf.yaml
@@ -1,0 +1,53 @@
+color: null
+fieldLayouts:
+  e399cfbc-ad49-4346-af55-44c91bafc80c:
+    tabs:
+      -
+        elementCondition: null
+        elements:
+          -
+            dateAdded: '2025-03-10T16:53:04+00:00'
+            elementCondition: null
+            fieldUid: f7d30e72-f872-487a-aba1-c8e95268a220 # Code Position
+            handle: null
+            includeInCards: false
+            instructions: null
+            label: null
+            providesThumbs: false
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 0945a6dc-8201-4deb-bbad-dc2af0e0dd9b
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            dateAdded: '2025-03-10T16:44:51+00:00'
+            elementCondition: null
+            fieldUid: 7a701601-ee6c-4d56-8bd0-efa7719f6a67 # Code
+            handle: null
+            includeInCards: false
+            instructions: null
+            label: null
+            providesThumbs: false
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 9848de68-0b9e-4a27-a38c-34a7f68eeaba
+            userCondition: null
+            warning: null
+            width: 100
+        name: Content
+        uid: 39937348-1f3d-4fa6-aaf3-cffe7a6c2a13
+        userCondition: null
+handle: codeBlock
+hasTitleField: false
+icon: code
+name: 'Code Block'
+showSlugField: false
+showStatusField: false
+slugTranslationKeyFormat: null
+slugTranslationMethod: site
+titleFormat: null
+titleTranslationKeyFormat: null
+titleTranslationMethod: site

--- a/config/project/entryTypes/globalCode--25362218-e66c-494e-9f2c-63e8cbc6ce0a.yaml
+++ b/config/project/entryTypes/globalCode--25362218-e66c-494e-9f2c-63e8cbc6ce0a.yaml
@@ -1,0 +1,55 @@
+color: null
+fieldLayouts:
+  f275bbb7-5f45-46ad-8feb-16f35f683456:
+    tabs:
+      -
+        elementCondition: null
+        elements:
+          -
+            dateAdded: '2025-03-10T17:00:59+00:00'
+            dismissible: false
+            elementCondition: null
+            style: warning
+            tip: "**Use Caution:** Improperly formatted code can break pages. \r\n\r\nBe sure to wrap any JavaScript in opening and closing tags. \r\n\r\n    <script>\r\n        // Your Code Here\r\n    </script> "
+            type: craft\fieldlayoutelements\Tip
+            uid: 6dae3c5a-5842-433f-93ff-8f5696852098
+            userCondition: null
+          -
+            content: "## Instructions\r\n\r\n**Code Positions**\r\n\r\n- **Start of <head>** - Code is loaded  at the beginning of the <head> tag. Only use when absolutely required.\r\n- **End of <head>** - Code is loaded at the end of the </head>.\r\n- **Start of <body>** - Code is loaded at the beginning of the <body> tag. \r\n- **End of <body>** - Code is loaded at the bottom of the <body> tag after all other scripts, styles and markup has loaded.  \r\nThis option has the lowest impact on page speed. "
+            dateAdded: '2025-03-10T17:02:50+00:00'
+            displayInPane: true
+            elementCondition: null
+            type: craft\fieldlayoutelements\Markdown
+            uid: c4baee17-adfa-4390-a757-7697c5e4752a
+            userCondition: null
+            width: 100
+          -
+            dateAdded: '2025-03-10T16:49:09+00:00'
+            elementCondition: null
+            fieldUid: 9c7dc3c3-cb8c-4167-880d-ab9426eef873 # Code Blocks
+            handle: null
+            includeInCards: false
+            instructions: null
+            label: null
+            providesThumbs: false
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: c37c8413-d135-4e9e-8d12-7ebca4b5662f
+            userCondition: null
+            warning: null
+            width: 100
+        name: Content
+        uid: 0cc45244-3937-457a-899e-6f786bb6b0a4
+        userCondition: null
+handle: globalCode
+hasTitleField: false
+icon: code
+name: 'Global Code'
+showSlugField: false
+showStatusField: false
+slugTranslationKeyFormat: null
+slugTranslationMethod: site
+titleFormat: null
+titleTranslationKeyFormat: null
+titleTranslationMethod: site

--- a/config/project/fields/code--7a701601-ee6c-4d56-8bd0-efa7719f6a67.yaml
+++ b/config/project/fields/code--7a701601-ee6c-4d56-8bd0-efa7719f6a67.yaml
@@ -1,0 +1,16 @@
+columnSuffix: null
+handle: code
+instructions: null
+name: Code
+searchable: false
+settings:
+  byteLimit: null
+  charLimit: null
+  code: true
+  initialRows: 4
+  multiline: true
+  placeholder: null
+  uiMode: normal
+translationKeyFormat: null
+translationMethod: none
+type: craft\fields\PlainText

--- a/config/project/fields/codeBlocks--9c7dc3c3-cb8c-4167-880d-ab9426eef873.yaml
+++ b/config/project/fields/codeBlocks--9c7dc3c3-cb8c-4167-880d-ab9426eef873.yaml
@@ -1,0 +1,25 @@
+columnSuffix: null
+handle: codeBlocks
+instructions: null
+name: 'Code Blocks'
+searchable: false
+settings:
+  createButtonLabel: 'Add Code Block'
+  defaultIndexViewMode: cards
+  entryTypes:
+    -
+      __assoc__:
+        -
+          - uid
+          - cbf3aeac-588c-4aeb-9573-6f1920206abf # Code Block
+  includeTableView: false
+  maxEntries: null
+  minEntries: null
+  pageSize: null
+  propagationKeyFormat: null
+  propagationMethod: all
+  showCardsInGrid: false
+  viewMode: blocks
+translationKeyFormat: null
+translationMethod: site
+type: craft\fields\Matrix

--- a/config/project/fields/codePosition--f7d30e72-f872-487a-aba1-c8e95268a220.yaml
+++ b/config/project/fields/codePosition--f7d30e72-f872-487a-aba1-c8e95268a220.yaml
@@ -1,0 +1,55 @@
+columnSuffix: null
+handle: codePosition
+instructions: null
+name: 'Code Position'
+searchable: false
+settings:
+  customOptions: false
+  options:
+    -
+      __assoc__:
+        -
+          - label
+          - 'Start of <head>'
+        -
+          - value
+          - headTop
+        -
+          - default
+          - ''
+    -
+      __assoc__:
+        -
+          - label
+          - 'End of <head>'
+        -
+          - value
+          - headBottom
+        -
+          - default
+          - '1'
+    -
+      __assoc__:
+        -
+          - label
+          - 'Start of <body>'
+        -
+          - value
+          - bodyTop
+        -
+          - default
+          - ''
+    -
+      __assoc__:
+        -
+          - label
+          - 'End of <body>'
+        -
+          - value
+          - bodyBottom
+        -
+          - default
+          - ''
+translationKeyFormat: null
+translationMethod: none
+type: craft\fields\Dropdown

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -1,4 +1,42 @@
-dateModified: 1741625195
+dateModified: 1741626559
+elementSources:
+  craft\elements\Entry:
+    -
+      defaultSort:
+        - postDate
+        - desc
+      defaultViewMode: ''
+      disabled: false
+      key: '*'
+      tableAttributes:
+        - status
+        - section
+        - postDate
+        - expiryDate
+        - link
+      type: native
+    -
+      heading: Singles
+      type: heading
+    -
+      key: 'single:969acdd6-6362-41b1-b782-6bbd43a8a6b4' # Home
+      type: native
+    -
+      heading: Globals
+      type: heading
+    -
+      defaultSort:
+        - id
+        - asc
+      defaultViewMode: ''
+      disabled: false
+      key: 'single:b4bfeb63-5bc4-4368-b4c9-408f7bac68fc' # Global Code
+      tableAttributes:
+        - status
+        - postDate
+        - expiryDate
+        - link
+      type: native
 email:
   fromEmail: $SYSTEM_EMAIL_FROM
   fromName: 'Viget Craft Starter'
@@ -26,9 +64,11 @@ meta:
     3bcf7ddb-71e7-4115-868c-815b3611b34c: 'Text With Media' # Text With Media
     3f1dc0c5-f091-469a-858a-4cbd3596bab7: 'Icon Card' # Icon Card
     5e84b0b7-6851-47ed-962e-76498ac9476f: 'Card Grid' # Card Grid
+    7a701601-ee6c-4d56-8bd0-efa7719f6a67: Code # Code
     7bd21dd3-6b12-4163-8432-030ea6a3f8d3: 'Page Blocks' # Page Blocks
     7ced3e9d-9b54-47f6-8103-e5c3a4fbaf9c: 'Card Grid' # Card Grid
     7d418368-91eb-4c64-8f5b-94c62cd62359: 'Image Card' # Image Card
+    9c7dc3c3-cb8c-4167-880d-ab9426eef873: 'Code Blocks' # Code Blocks
     0011a64a-91b6-4aa3-98e6-be048394a2cf: Icon # Icon
     27f19bae-64f8-47b8-9fc9-7552e11e2656: 'Page Hero' # Page Hero
     35b563a0-4662-40b9-b885-a8450a2868d9: 'Viget Craft Starter' # Viget Craft Starter
@@ -42,15 +82,19 @@ meta:
     969acdd6-6362-41b1-b782-6bbd43a8a6b4: Home # Home
     4382f55f-01a1-4b67-84c8-ebbc89b238d2: Heading # Heading
     853413e4-e02c-487e-81a5-04e58eb18683: Assets # Assets
+    25362218-e66c-494e-9f2c-63e8cbc6ce0a: 'Global Code' # Global Code
     a99edea2-f8ae-44e5-a12f-89cb9aa66738: Description # Description
     ac3b0590-d417-429e-aa1f-96be3c79a5b0: 'Media Type' # Media Type
     b3d7753a-c7ad-4f33-aca8-df63277e9b42: 'Primary Navigation' # Primary Navigation
+    b4bfeb63-5bc4-4368-b4c9-408f7bac68fc: 'Global Code' # Global Code
     b7e66782-af96-4012-9e17-914134073ced: Simple # Simple
     c52a9170-652b-4d92-a226-69894b1822ed: 'Rich Text: Simple' # Rich Text: Simple
+    cbf3aeac-588c-4aeb-9573-6f1920206abf: 'Code Block' # Code Block
     cd489d3c-f914-475c-a270-ab926e4e7485: 'Rich Text' # Rich Text
     d7f9c488-b14d-48c2-b6fc-d616b7a9f49f: 'Show Media On' # Show Media On
     d39724b0-dd22-4c74-aa0b-87a022555cf2: Advanced # Advanced
     e445a3b9-5827-422a-8328-6b10449fa891: Heading # Heading
+    f7d30e72-f872-487a-aba1-c8e95268a220: 'Code Position' # Code Position
 plugins:
   aws-s3:
     edition: standard

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1740184038
+dateModified: 1741625195
 email:
   fromEmail: $SYSTEM_EMAIL_FROM
   fromName: 'Viget Craft Starter'
@@ -72,6 +72,13 @@ plugins:
     edition: standard
     enabled: true
     schemaVersion: 1.0.0
+  expanded-singles:
+    edition: standard
+    enabled: true
+    schemaVersion: 1.0.0
+    settings:
+      expandSingles: true
+      redirectToEntry: true
   imager-x:
     edition: lite
     enabled: true

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1741626559
+dateModified: 1741627776
 elementSources:
   craft\elements\Entry:
     -

--- a/config/project/sections/globalCode--b4bfeb63-5bc4-4368-b4c9-408f7bac68fc.yaml
+++ b/config/project/sections/globalCode--b4bfeb63-5bc4-4368-b4c9-408f7bac68fc.yaml
@@ -1,0 +1,16 @@
+defaultPlacement: end
+enableVersioning: true
+entryTypes:
+  -
+    uid: 25362218-e66c-494e-9f2c-63e8cbc6ce0a # Global Code
+handle: globalCode
+maxAuthors: 1
+name: 'Global Code'
+propagationMethod: all
+siteSettings:
+  35b563a0-4662-40b9-b885-a8450a2868d9: # Viget Craft Starter
+    enabledByDefault: true
+    hasUrls: false
+    template: null
+    uriFormat: null
+type: single

--- a/templates/_layouts/base.twig
+++ b/templates/_layouts/base.twig
@@ -1,40 +1,65 @@
+{%- set globalCode = craft.entries.section('globalCode').one() -%}
+{%- set codeBlocks = globalCode.codeBlocks.collect() -%}
+{%- set codeBlocksTemplate = '_partials/global-code-blocks.twig' -%}
 <!DOCTYPE html>
 <html dir="auto" lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  {# -- Dangerously added raw HTML -- #}
+  {{ include(codeBlocksTemplate, {
+    codeBlocks,
+    codePosition: 'headTop'
+  }) }}
 
-    <title>{{ siteName }}</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    {# Preload Webfonts #}
-    <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-bold-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-light-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-regular-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-semibold-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
+  <title>{{ siteName }}</title>
 
-    {# Load our main CSS file to avoid FOUC in dev mode #}
-    {% if craft.vite.devServerRunning() %}
-        <link rel="stylesheet" href="{{ craft.vite.asset("src/css/app.css") }}">
-    {% endif %}
+  {# Preload Webfonts #}
+  <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-bold-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-light-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-regular-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-semibold-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
 
-    {{ craft.vite.script('src/js/app.js', false) }}
+  {# Load our main CSS file to avoid FOUC in dev mode #}
+  {% if craft.vite.devServerRunning() %}
+    <link rel="stylesheet" href="{{ craft.vite.asset("src/css/app.css") }}">
+  {% endif %}
 
-    {# Hide elements if we're in the parts-kit #}
-    {% set isPartsKitUrl = craft.app.request.segments | first == 'parts-kit' %}
+  {{ craft.vite.script('src/js/app.js', false) }}
+
+  {# Hide elements if we're in the parts-kit #}
+  {% set isPartsKitUrl = craft.app.request.segments | first == 'parts-kit' %}
+
+  {# -- Dangerously added raw HTML -- #}
+  {{ include(codeBlocksTemplate, {
+    codeBlocks,
+    codePosition: 'headBottom'
+  }) }}
 </head>
 <body>
+  {# -- Dangerously added raw HTML -- #}
+  {{ include(codeBlocksTemplate, {
+    codeBlocks,
+    codePosition: 'bodyTop'
+  }) }}
 
-    {% if not isPartsKitUrl %}
-        {{ include('_partials/header.twig') }}
-    {% endif %}
+  {% if not isPartsKitUrl %}
+      {{ include('_partials/header.twig') }}
+  {% endif %}
 
-    <main id="content" tabindex="-1">
-        {% block content %}{% endblock %}
-    </main>
+  <main id="content" tabindex="-1">
+    {% block content %}{% endblock %}
+  </main>
 
-    {% if not isPartsKitUrl %}
-        {{ include('_partials/footer.twig') }}
-    {% endif %}
+  {% if not isPartsKitUrl %}
+    {{ include('_partials/footer.twig') }}
+  {% endif %}
 
+  {# -- Dangerously added raw HTML -- #}
+  {{ include(codeBlocksTemplate, {
+    codeBlocks,
+    codePosition: 'bodyBottom'
+  }) }}
 </body>
 </html>

--- a/templates/_layouts/base.twig
+++ b/templates/_layouts/base.twig
@@ -1,4 +1,3 @@
-{%- set globalCode = craft.entries.section('globalCode').one() -%}
 {%- set codeBlocks = globalCode.codeBlocks.collect() -%}
 {%- set codeBlocksTemplate = '_partials/global-code-blocks.twig' -%}
 <!DOCTYPE html>
@@ -13,7 +12,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  <title>{{ siteName }}</title>
+  {% if seomatic is not defined -%}
+    <title>{{ siteName }}</title>
+  {%- endif %}
 
   {# Preload Webfonts #}
   <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-bold-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>

--- a/templates/_partials/global-code-blocks.twig
+++ b/templates/_partials/global-code-blocks.twig
@@ -1,16 +1,18 @@
-{# @var \Illuminate\Support\Collection<\craft\elements\Entry> blocks #}
-{% set codeBlocks = codeBlocks ?? collect([]) %}
+{% apply spaceless %}
+  {# @var \Illuminate\Support\Collection<\craft\elements\Entry> blocks #}
+  {% set codeBlocks = codeBlocks ?? collect([]) %}
 
-{# @var string codePosition - Required #}
-{% set codePosition = codePosition ?? null %}
+  {# @var string codePosition - Required #}
+  {% set codePosition = codePosition ?? null %}
 
-{% set validPositions = ['headTop', 'headBottom', 'bodyTop', 'bodyBottom'] %}
+  {% set validPositions = ['headTop', 'headBottom', 'bodyTop', 'bodyBottom'] %}
 
-{% set blocksForPosition = codeBlocks|filter(block => (block.codePosition.value == codePosition)) %}
+  {% set blocksForPosition = codeBlocks|filter(block => (block.codePosition.value|default == codePosition)) %}
 
-{% if blocksForPosition|length and codePosition in validPositions %}
-  {% for block in blocksForPosition %}
-    {# -- Dangerously added raw HTML -- #}
-    {{ block.code|raw }}
-  {% endfor %}
-{% endif %}
+  {% if blocksForPosition|length and codePosition in validPositions %}
+    {% for block in blocksForPosition %}
+      {# -- Dangerously added raw HTML -- #}
+      {{ block.code|raw }}
+    {% endfor %}
+  {% endif %}
+{% endapply %}

--- a/templates/_partials/global-code-blocks.twig
+++ b/templates/_partials/global-code-blocks.twig
@@ -1,0 +1,16 @@
+{# @var \Illuminate\Support\Collection<\craft\elements\Entry> blocks #}
+{% set codeBlocks = codeBlocks ?? collect([]) %}
+
+{# @var string codePosition - Required #}
+{% set codePosition = codePosition ?? null %}
+
+{% set validPositions = ['headTop', 'headBottom', 'bodyTop', 'bodyBottom'] %}
+
+{% set blocksForPosition = codeBlocks|filter(block => (block.codePosition.value == codePosition)) %}
+
+{% if blocksForPosition|length and codePosition in validPositions %}
+  {% for block in blocksForPosition %}
+    {# -- Dangerously added raw HTML -- #}
+    {{ block.code|raw }}
+  {% endfor %}
+{% endif %}


### PR DESCRIPTION
## Overview
- https://github.com/vigetlabs/craft-site-starter/issues/67

This PR replaces https://github.com/vigetlabs/craft-site-starter/pull/82. 

I decided to use @maxfenton's neat way of incorporating global scripts on Ad Council websites. 

This PR also installs [Verbb's expanded singles](https://plugins.craftcms.com/expanded-singles) plugin. 

## Screenshots

### Craft Admin

![CleanShot 2025-03-10 at 10 31 52@2x](https://github.com/user-attachments/assets/874658d5-7b31-4229-8f9b-8a5e2ce54fb8)


![CleanShot 2025-03-10 at 10 29 59@2x](https://github.com/user-attachments/assets/a8717188-08b5-43e1-b7db-f3532f8f1f1f)

### Frontend

![CleanShot 2025-03-10 at 10 31 13@2x](https://github.com/user-attachments/assets/4a82c82d-0e6f-4a38-8787-1752d1b75207)
