### PR TITLE
[n/a] Prevent ddev notice about upload_dirs

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -34,6 +34,7 @@ web_extra_daemons:
   - name: 'vite'
     command: 'npm install && npm run build && npm run dev'
     directory: /var/www/html
+disable_upload_dirs_warning: true
 # Key features of ddev's config.yaml:
 
 # name: <projectname> # Name of the project, automatically provides


### PR DESCRIPTION
Add `disable_upload_dirs_warning: true` to `.ddev/config.yaml` to prevent a notice about `upload_dirs` not being set.