### PR TITLE
[#5] Adds ddev command to visualize Vite bundle

### DIFF
--- a/.ddev/commands/host/vite-visualizer.sh
+++ b/.ddev/commands/host/vite-visualizer.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+## Description: Analyze and visualize the Vite bundle with the current project
+## OSTypes: darwin
+## Usage: vite-visualizer
+## Example: "ddev vite-visualizer"
+## See: https://www.npmjs.com/package/vite-bundle-visualizer
+
+ddev exec npx vite-bundle-visualizer -o vite-bundle-visualizer.html
+
+open "${DDEV_APPROOT}/vite-bundle-visualizer.html"

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ node_modules
 /web/imager
 /.vite
 php-cs-fixer.cache
+# Ignore generated visualization files
+vite-bundle-visualizer.html
 
 # BEGIN-STARTER-ONLY
 config/license.key


### PR DESCRIPTION
### Overview
- #5 

I've been using this package on MW and it's handy for getting a grasp of bundle size. 

This PR adds a custom DDEV command that does the following. 

- Runs the bundle visualizer from within DDEV
- Opens the generated HTML file so you can view the results. 

If we weren't using ddev, simply running `npx vite-bundle-visualizer` automatically opens visualization. 

However, we want to run the command within ddev so it makes use of the proper node versions, etc. 

The custom host command helps orchestrate the two steps of running npx within ddev, but opening the output file in our host machine. 

### Example

Run the following command

```
ddev vite-visualizer
```

### Screenshots

![CleanShot 2025-05-23 at 16 42 25](https://github.com/user-attachments/assets/ae490396-b6c8-49b9-ae17-8a31cc122182)


![CleanShot 2025-05-23 at 16 47 56@2x](https://github.com/user-attachments/assets/63018571-713c-45d9-a5b6-7dc45a5b7253)
