### PR TITLE
[#113] Add ariaHidden prop to Icon macro (hidden by default)

### DIFF
--- a/templates/_components/icon.twig
+++ b/templates/_components/icon.twig
@@ -18,6 +18,9 @@ By setting size to `none` you can add arbitrary size classes to the icon.
   {# @var string|null class #}
   {% set class = props.class ?? null %}
 
+  {# @var bool ariaHidden #}
+  {% set ariaHidden = props.ariaHidden ?? true %}
+
   {# Computed values #}
   {% set sizeConfig = {
     'sm': 'size-16',
@@ -30,5 +33,6 @@ By setting size to `none` you can add arbitrary size classes to the icon.
 
   {{ svg('@webroot/dist/assets/icons/' ~ name ~ '.svg')|attr({
     class: cx(sizeClass, class),
+    'aria-hidden': ariaHidden ? 'true' : null,
   }) }}
 {% endmacro %}

--- a/templates/parts-kit/icons/default.twig
+++ b/templates/parts-kit/icons/default.twig
@@ -28,6 +28,15 @@
           </div>
         {% endfor %}
       </div>
+      <h2 class="text-xl font-bold">Accessibility</h2>
+      <p class="text-sm text-gray-500">
+        Icons are hidden from screen readers by default. Use <code>ariaHidden: false</code> to show the icon to screen readers.
+      </p>
+
+      {{ Icon({
+        name: 'arrow-right',
+        ariaHidden: false,
+      }) }}
     </div>
   {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Something I noticed on Ad Council's EFF site. 

Most icons are decorative and should be hidden. This gives us the ability to make icons visible / hidden to screen readers.

Decided to until we sort out icon loading before working on `titles` for icons. 

- https://github.com/vigetlabs/craft-site-starter/issues/118
- https://github.com/vigetlabs/craft-site-starter/issues/117