### PR TITLE
Parts Kit 2 of 2: Upgrade Templates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "verbb/expanded-singles": "3.0.3",
     "verbb/navigation": "3.0.13",
     "viget/craft-classnames": "3.0.0",
-    "viget/craft-parts-kit": "dev-jp/plugin-release",
+    "viget/craft-parts-kit": "dev-jp/settings-and-remove-layout-dependency",
     "vlucas/phpdotenv": "^5.4.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7eed07ec961dd9c52509228576cfec9f",
+    "content-hash": "c7f8009cd90cf35e37b75a5dc50ba928",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -8802,16 +8802,16 @@
         },
         {
             "name": "viget/craft-parts-kit",
-            "version": "dev-jp/plugin-release",
+            "version": "dev-jp/settings-and-remove-layout-dependency",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vigetlabs/craft-parts-kit.git",
-                "reference": "7b9f68ca42c8896b254a5c0c331e1001cac659d0"
+                "reference": "14ce907e956e375c2fa286c95e309cd652dc11b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vigetlabs/craft-parts-kit/zipball/7b9f68ca42c8896b254a5c0c331e1001cac659d0",
-                "reference": "7b9f68ca42c8896b254a5c0c331e1001cac659d0",
+                "url": "https://api.github.com/repos/vigetlabs/craft-parts-kit/zipball/14ce907e956e375c2fa286c95e309cd652dc11b6",
+                "reference": "14ce907e956e375c2fa286c95e309cd652dc11b6",
                 "shasum": ""
             },
             "require": {
@@ -8850,10 +8850,10 @@
             ],
             "support": {
                 "email": "craft@viget.com",
-                "source": "https://github.com/vigetlabs/craft-parts-kit/tree/jp/plugin-release",
+                "source": "https://github.com/vigetlabs/craft-parts-kit/tree/jp/settings-and-remove-layout-dependency",
                 "issues": "https://github.com/vigetlabs/craft-parts-kit/issues"
             },
-            "time": "2025-10-31T17:53:53+00:00"
+            "time": "2025-10-31T22:46:49+00:00"
         },
         {
             "name": "vlucas/phpdotenv",

--- a/config/parts-kit.php
+++ b/config/parts-kit.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'headTemplatePath' => '_partials/head.twig',
+];

--- a/templates/_layouts/base.twig
+++ b/templates/_layouts/base.twig
@@ -16,21 +16,7 @@
     <title>{{ siteName }}</title>
   {%- endif %}
 
-  {# Preload Webfonts #}
-  <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-bold-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-light-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-regular-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
-  <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-semibold-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
-
-  {# Load our main CSS file to avoid FOUC in dev mode #}
-  {% if craft.vite.devServerRunning() %}
-    <link rel="stylesheet" href="{{ craft.vite.asset("src/css/app.css") }}">
-  {% endif %}
-
-  {{ craft.vite.script('src/js/app.js', false) }}
-
-  {# Hide elements if we're in the parts-kit #}
-  {% set isPartsKitUrl = craft.app.request.segments | first == 'parts-kit' %}
+  {{ include('_partials/head.twig') }}
 
   {# -- Dangerously added raw HTML -- #}
   {{ include(codeBlocksTemplate, {
@@ -45,17 +31,13 @@
     codePosition: 'bodyTop'
   }, with_context = false) }}
 
-  {% if not isPartsKitUrl %}
-      {{ include('_partials/header.twig') }}
-  {% endif %}
+  {{ include('_partials/header.twig') }}
 
   <main id="content" tabindex="-1">
     {% block content %}{% endblock %}
   </main>
 
-  {% if not isPartsKitUrl %}
-    {{ include('_partials/footer.twig') }}
-  {% endif %}
+  {{ include('_partials/footer.twig') }}
 
   {# -- Dangerously added raw HTML -- #}
   {{ include(codeBlocksTemplate, {

--- a/templates/_partials/head.twig
+++ b/templates/_partials/head.twig
@@ -1,0 +1,12 @@
+  {# Preload Webfonts #}
+  <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-bold-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-light-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-regular-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="{{ craft.vite.asset("src/fonts/sourcesanspro-semibold-webfont.woff2") }}" as="font" type="font/woff2" crossorigin>
+
+  {# Load our main CSS file to avoid FOUC in dev mode #}
+  {% if craft.vite.devServerRunning() %}
+    <link rel="stylesheet" href="{{ craft.vite.asset("src/css/app.css") }}">
+  {% endif %}
+
+  {{ craft.vite.script('src/js/app.js', false) }}

--- a/templates/parts-kit/accordion/default.twig
+++ b/templates/parts-kit/accordion/default.twig
@@ -1,26 +1,22 @@
-{% extends "parts-kit/layout.twig" %}
 {% from '_components/accordion' import Accordion %}
 
-{% block main %}
+<div>
+  {% for i in 1..3 %}
+    {{ Accordion({
+      title: 'Accordion Item ' ~ i,
+      content: 'This is the content for accordion item ' ~ i ~ '.',
+    }) }}
+  {% endfor %}
+</div>
 
-  <div>
-    {% for i in 1..3 %}
-      {{ Accordion({
-        title: 'Accordion Item ' ~ i,
-        content: 'This is the content for accordion item ' ~ i ~ '.',
-      }) }}
-    {% endfor %}
-  </div>
+<h2 class="text-2xl font-bold mb-16 mt-40">Grouped Accordions</h2>
 
-  <h2 class="text-2xl font-bold mb-16 mt-40">Grouped Accordions</h2>
-
-  <div>
-    {% for i in 1..3 %}
-      {{ Accordion({
-        title: 'Accordion Item ' ~ i,
-        content: 'This is the content for accordion item ' ~ i ~ '.',
-        name: 'accordion-group',
-      }) }}
-    {% endfor %}
-  </div>
-{% endblock %}
+<div>
+  {% for i in 1..3 %}
+    {{ Accordion({
+      title: 'Accordion Item ' ~ i,
+      content: 'This is the content for accordion item ' ~ i ~ '.',
+      name: 'accordion-group',
+    }) }}
+  {% endfor %}
+</div>

--- a/templates/parts-kit/alert-banner/default.twig
+++ b/templates/parts-kit/alert-banner/default.twig
@@ -1,19 +1,15 @@
-{% extends 'parts-kit/layout.twig' %}
-
 {% from '_components/alert-banner' import AlertBanner %}
 
-{% block main %}
-  {{ AlertBanner({
-    title: 'Dismissible Alert Banner',
-    description: 'Cillum dolor nisi et sunt in in et ullamco eiusmod duis aute et fugiat excepteur. Sit irure consectetur anim do aliqua excepteur amet nulla magna enim proident incididunt ipsum.',
-    dismissible: true,
-  }) }}
+{{ AlertBanner({
+  title: 'Dismissible Alert Banner',
+  description: 'Cillum dolor nisi et sunt in in et ullamco eiusmod duis aute et fugiat excepteur. Sit irure consectetur anim do aliqua excepteur amet nulla magna enim proident incididunt ipsum.',
+  dismissible: true,
+}) }}
 
-  <hr class="my-48" />
+<hr class="my-48" />
 
-  {{ AlertBanner({
-    title: 'Non-Dismissible Alert Banner',
-    description: 'Cillum dolor nisi et sunt in in et ullamco eiusmod duis aute et fugiat excepteur. Sit irure consectetur anim do aliqua excepteur amet nulla magna enim proident incididunt ipsum.',
-    dismissible: false,
-  }) }}
-{% endblock %}
+{{ AlertBanner({
+  title: 'Non-Dismissible Alert Banner',
+  description: 'Cillum dolor nisi et sunt in in et ullamco eiusmod duis aute et fugiat excepteur. Sit irure consectetur anim do aliqua excepteur amet nulla magna enim proident incididunt ipsum.',
+  dismissible: false,
+}) }}

--- a/templates/parts-kit/button/default.twig
+++ b/templates/parts-kit/button/default.twig
@@ -1,117 +1,114 @@
-{% extends 'parts-kit/layout.twig' %}
-
 {% from '_components/button' import Button %}
 
 {% set sizes = ['sm', 'md', 'lg'] %}
 
-{% block main %}
-  <div class="flex flex-col gap-16">
-    {% for size in sizes %}
-      <div class="flex items-center gap-16">
-        <h3 class="text-lg font-bold">{{ size }}</h3>
+<div class="flex flex-col gap-16">
+  {% for size in sizes %}
+    <div class="flex items-center gap-16">
+      <h3 class="text-lg font-bold">{{ size }}</h3>
 
-        {{ Button({
-          variant: 'contained',
-          text: 'Button',
-          size,
-        }) }}
+      {{ Button({
+        variant: 'contained',
+        text: 'Button',
+        size,
+      }) }}
 
-        {{ Button({
-          variant: 'outlined',
-          text: 'Button',
-          size,
-        }) }}
+      {{ Button({
+        variant: 'outlined',
+        text: 'Button',
+        size,
+      }) }}
 
-        {{ Button({
-          variant: 'subtle',
-          text: 'Button',
-          size,
-        }) }}
+      {{ Button({
+        variant: 'subtle',
+        text: 'Button',
+        size,
+      }) }}
 
-        {{ Button({
-          variant: 'text',
-          text: 'Button',
-          size,
-        }) }}
-      </div>
-    {% endfor %}
-  </div>
+      {{ Button({
+        variant: 'text',
+        text: 'Button',
+        size,
+      }) }}
+    </div>
+  {% endfor %}
+</div>
 
-  <hr class="my-32">
+<hr class="my-32">
 
-  <div class="flex flex-col gap-16">
-    <h1 class="text-2xl font-bold">With Icon</h1>
-    {% for size in sizes %}
-      <div class="flex items-center gap-16">
-        <h3 class="text-lg font-bold">{{ size }}</h3>
-        {{ Button({
-          variant: 'contained',
-          text: 'Button',
-          size,
-          icon: 'arrow-right',
-        }) }}
+<div class="flex flex-col gap-16">
+  <h1 class="text-2xl font-bold">With Icon</h1>
 
-        {{ Button({
-          variant: 'contained',
-          text: 'Button',
-          size,
-          icon: 'arrow-right',
-          iconLast: true,
-        }) }}
+  {% for size in sizes %}
+    <div class="flex items-center gap-16">
+      <h3 class="text-lg font-bold">{{ size }}</h3>
+      {{ Button({
+        variant: 'contained',
+        text: 'Button',
+        size,
+        icon: 'arrow-right',
+      }) }}
 
-        {{ Button({
-          variant: 'contained',
-          text: 'Button',
-          size,
-          icon: 'arrow-right',
-          iconOnly: true,
-        }) }}
+      {{ Button({
+        variant: 'contained',
+        text: 'Button',
+        size,
+        icon: 'arrow-right',
+        iconLast: true,
+      }) }}
 
-        {{ Button({
-          variant: 'outlined',
-          text: 'Button',
-          size,
-          icon: 'arrow-right',
-        }) }}
+      {{ Button({
+        variant: 'contained',
+        text: 'Button',
+        size,
+        icon: 'arrow-right',
+        iconOnly: true,
+      }) }}
 
-        {{ Button({
-          variant: 'outlined',
-          text: 'Button',
-          size,
-          icon: 'arrow-right',
-          iconOnly: true,
-        }) }}
+      {{ Button({
+        variant: 'outlined',
+        text: 'Button',
+        size,
+        icon: 'arrow-right',
+      }) }}
 
-        {{ Button({
-          variant: 'subtle',
-          text: 'Button',
-          size,
-          icon: 'arrow-right',
-        }) }}
+      {{ Button({
+        variant: 'outlined',
+        text: 'Button',
+        size,
+        icon: 'arrow-right',
+        iconOnly: true,
+      }) }}
 
-        {{ Button({
-          variant: 'subtle',
-          iconOnly: true,
-          text: 'Button',
-          size,
-          icon: 'arrow-right',
-        }) }}
+      {{ Button({
+        variant: 'subtle',
+        text: 'Button',
+        size,
+        icon: 'arrow-right',
+      }) }}
 
-        {{ Button({
-          variant: 'text',
-          text: 'Button',
-          size,
-          icon: 'arrow-right',
-        }) }}
+      {{ Button({
+        variant: 'subtle',
+        iconOnly: true,
+        text: 'Button',
+        size,
+        icon: 'arrow-right',
+      }) }}
 
-        {{ Button({
-          variant: 'text',
-          text: 'Button',
-          size,
-          icon: 'arrow-right',
-          iconOnly: true,
-        }) }}
-      </div>
-    {% endfor %}
-  </div>
-{% endblock %}
+      {{ Button({
+        variant: 'text',
+        text: 'Button',
+        size,
+        icon: 'arrow-right',
+      }) }}
+
+      {{ Button({
+        variant: 'text',
+        text: 'Button',
+        size,
+        icon: 'arrow-right',
+        iconOnly: true,
+      }) }}
+    </div>
+  {% endfor %}
+</div>

--- a/templates/parts-kit/call-to-action/default.twig
+++ b/templates/parts-kit/call-to-action/default.twig
@@ -1,13 +1,9 @@
-{% extends 'parts-kit/layout.twig' %}
-
 {% from '_components/call-to-action' import CallToAction %}
 
-{% block main %}
-  {{ CallToAction({
-    title: 'Lorem ipsum dolor sit amet',
-    text: 'Lorem ipsum dolor sit amet, consectetur adipiscing e lit. Nulla facilisi. Nulla facilisi. Nulla facilisi.',
-    href: '#TEST',
-    buttonText: 'Button',
-    newTab: true,
-  }) }}
-{% endblock %}
+{{ CallToAction({
+  title: 'Lorem ipsum dolor sit amet',
+  text: 'Lorem ipsum dolor sit amet, consectetur adipiscing e lit. Nulla facilisi. Nulla facilisi. Nulla facilisi.',
+  href: '#TEST',
+  buttonText: 'Button',
+  newTab: true,
+}) }}

--- a/templates/parts-kit/dialog/default.twig
+++ b/templates/parts-kit/dialog/default.twig
@@ -1,17 +1,13 @@
-{% extends "parts-kit/layout.twig" %}
-
 {% from '_components/button' import Button %}
 {% from '_components/dialog' import Dialog %}
 
-{% block main %}
+{% set content %}
+  <p>Hello World</p>
+  <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. <a href="#">Quisquam, quos.</a></p>
+{% endset %}
 
-  {% set content %}
-    <p>Hello World</p>
-    <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. <a href="#">Quisquam, quos.</a></p>
-  {% endset %}
-
-  {# Dialogs are triggered by dispatching a custom event dialog:open with an id that matches the dialog's id #}
-  {{ Button({
+{# Dialogs are triggered by dispatching a custom event dialog:open with an id that matches the dialog's id #}
+{{ Button({
     text: 'Open Dialog',
     attrs: {
       'x-data': '',
@@ -19,9 +15,8 @@
     },
   }) }}
 
-  {{ Dialog({
-    content,
-    id: 'my-dialog',
-    hideClose: true,
-  }) }}
-{% endblock %}
+{{ Dialog({
+  content,
+  id: 'my-dialog',
+  hideClose: true,
+}) }}

--- a/templates/parts-kit/icons/default.twig
+++ b/templates/parts-kit/icons/default.twig
@@ -1,42 +1,37 @@
-{% extends 'parts-kit/layout.twig' %}
-
 {% from '_components/icon.twig' import Icon %}
 
 {% set sizes = ['sm', 'md', 'lg', 'none'] %}
 
 {% set icons = ['arrow-left', 'arrow-right', 'clock', 'close'] %}
 
-{% block main %}
-
-  {% for size in sizes %}
-    <div class="container flex flex-col gap-24 mb-48">
-      <h2 class="text-2xl font-bold">
-        {{ size }}
-        {% if size == 'none' %}
-          <span class="block text-sm font-normal text-gray-500">Custom size class</span>
-        {% endif %}
-      </h2>
-      <div class="grid grid-cols-8 gap-16">
-        {% for icon in icons %}
-          <div class="flex flex-col items-center gap-8 border border-gray-200 rounded-md p-16">
-            {{ Icon({
-              name: icon,
-              size: size,
-              class: size == 'none' ? 'size-64' : null,
-            }) }}
-            <span class="text-sm text-gray-500">{{ icon }}</span>
-          </div>
-        {% endfor %}
-      </div>
-      <h2 class="text-xl font-bold">Accessibility</h2>
-      <p class="text-sm text-gray-500">
-        Icons are hidden from screen readers by default. Use <code>ariaHidden: false</code> to show the icon to screen readers.
-      </p>
-
-      {{ Icon({
-        name: 'arrow-right',
-        ariaHidden: false,
-      }) }}
+{% for size in sizes %}
+  <div class="container flex flex-col gap-24 mb-48">
+    <h2 class="text-2xl font-bold">
+      {{ size }}
+      {% if size == 'none' %}
+        <span class="block text-sm font-normal text-gray-500">Custom size class</span>
+      {% endif %}
+    </h2>
+    <div class="grid grid-cols-8 gap-16">
+      {% for icon in icons %}
+        <div class="flex flex-col items-center gap-8 border border-gray-200 rounded-md p-16">
+          {{ Icon({
+            name: icon,
+            size: size,
+            class: size == 'none' ? 'size-64' : null,
+          }) }}
+          <span class="text-sm text-gray-500">{{ icon }}</span>
+        </div>
+      {% endfor %}
     </div>
-  {% endfor %}
-{% endblock %}
+    <h2 class="text-xl font-bold">Accessibility</h2>
+    <p class="text-sm text-gray-500">
+      Icons are hidden from screen readers by default. Use <code>ariaHidden: false</code> to show the icon to screen readers.
+    </p>
+
+    {{ Icon({
+      name: 'arrow-right',
+      ariaHidden: false,
+    }) }}
+  </div>
+{% endfor %}

--- a/templates/parts-kit/image-caption/default.twig
+++ b/templates/parts-kit/image-caption/default.twig
@@ -1,5 +1,3 @@
-{% extends 'parts-kit/layout.twig' %}
-
 {% from '_components/image-caption' import ImageCaption %}
 
 {#
@@ -11,16 +9,14 @@ Use the same props that are defined in the image component.
 
 #}
 
-{% block main %}
-  <div class="container flex flex-col py-64 gap-32">
-    <h2 class="text-xl font-bold">Image Caption</h2>
+<div class="container flex flex-col py-64 gap-32">
+  <h2 class="text-xl font-bold">Image Caption</h2>
 
-    {{ ImageCaption({
-      imageProps: {
-        image: craft.assets().one(),
-        ratio: 16/9,
-      },
-      caption: 'Image caption',
-    }) }}
-  </div>
-{% endblock %}
+  {{ ImageCaption({
+    imageProps: {
+      image: craft.assets().one(),
+      ratio: 16/9,
+    },
+    caption: 'Image caption',
+  }) }}
+</div>

--- a/templates/parts-kit/image/default.twig
+++ b/templates/parts-kit/image/default.twig
@@ -1,5 +1,3 @@
-{% extends 'parts-kit/layout.twig' %}
-
 {% from '_components/image' import Image %}
 
 {#
@@ -50,83 +48,80 @@
       >
 #}
 
-{% block main %}
+<div class="container flex flex-col py-64 gap-32">
+  {#
+    Basic Example:
+    Transforms and sizes are configured to work well with the .container class.
+  #}
+  <h2 class="text-xl font-bold">Basic Example</h2>
+  {{ Image({
+    image: craft.assets.one(),
+    ratio: 16/9,
+  }) }}
 
-  <div class="container flex flex-col py-64 gap-32">
-
-    {#
-      Basic Example:
-      Transforms and sizes are configured to work well with the .container class.
-    #}
-    <h2 class="text-xl font-bold">Basic Example</h2>
-    {{ Image({
-      image: craft.assets.one(),
-      ratio: 16/9,
-    }) }}
-
-    {#
-      Custom Sizes:
-      The keys of the sizes attribute correspond to the breakpoints in your Tailwind config.
-      It uses a mobile first approach, default is the size used without a breakpoint.
-    #}
-    <div class="grid gap-16 grid-cols-2 sm:grid-cols-4 md:grid-cols-3">
-      <div>
-        <h2 class="text-xl font-bold mb-16">Custom Sizes</h2>
-        {{ Image({
-          image: craft.assets.one(),
-          sizes: {
-            default: '50vw',
-            sm: '25vw',
-            md: '33vw',
-          },
-        }) }}
-      </div>
-      <div>
-        <h2 class="text-xl font-bold mb-16">Custom Sizes and Aspect Ratio</h2>
-        {{ Image({
-          image: craft.assets.one(),
-          sizes: {
-            default: '50vw',
-            sm: '25vw',
-            md: '33vw',
-          },
-          ratio: 3/4,
-        }) }}
-      </div>
-      <div>
-        {#
-          Named Transform:
-          If you need to use a named transform, you can pass a string into the `transform` prop.
-        #}
-        <h2 class="text-xl font-bold mb-16">Named Transform</h2>
-        {{ Image({
-          image: craft.assets.one(),
-          transform: 'exampleNamedTransform',
-          sizes: {
-            default: '50vw',
-            sm: '25vw',
-            md: '33vw',
-          },
-        }) }}
-      </div>
-      <div>
-        {#
-          Scalar Sizes
-          This component supports custom transforms and scalar values for the sizes prop.
-        #}
-        <h2 class="text-xl font-bold mb-16">Scalar Sizes & Custom Transform</h2>
-        {{ Image({
-          image: craft.assets.one(),
-          class: 'size-40',
-          transformMinWidth: 40,
-          transformMaxWidth: 80,
-          transformAutofillCount: 0,
-          ratio: 1/1,
-          sizes: '40px',
-        }) }}
-      </div>
+  {#
+    Custom Sizes:
+    The keys of the sizes attribute correspond to the breakpoints in your Tailwind config.
+    It uses a mobile first approach, default is the size used without a breakpoint.
+  #}
+  <div class="grid gap-16 grid-cols-2 sm:grid-cols-4 md:grid-cols-3">
+    <div>
+      <h2 class="text-xl font-bold mb-16">Custom Sizes</h2>
+      {{ Image({
+        image: craft.assets.one(),
+        sizes: {
+          default: '50vw',
+          sm: '25vw',
+          md: '33vw',
+        },
+      }) }}
+    </div>
+    <div>
+      <h2 class="text-xl font-bold mb-16">Custom Sizes and Aspect Ratio</h2>
+      {{ Image({
+        image: craft.assets.one(),
+        sizes: {
+          default: '50vw',
+          sm: '25vw',
+          md: '33vw',
+        },
+        ratio: 3/4,
+      }) }}
+    </div>
+    <div>
+      {#
+        Named Transform:
+        If you need to use a named transform, you can pass a string into the `transform` prop.
+      #}
+      <h2 class="text-xl font-bold mb-16">Named Transform</h2>
+      {{ Image({
+        image: craft.assets.one(),
+        transform: 'exampleNamedTransform',
+        sizes: {
+          default: '50vw',
+          sm: '25vw',
+          md: '33vw',
+        },
+      }) }}
+    </div>
+    <div>
+      {#
+        Scalar Sizes
+        This component supports custom transforms and scalar values for the sizes prop.
+      #}
+      <h2 class="text-xl font-bold mb-16">Scalar Sizes & Custom Transform</h2>
+      {{ Image({
+        image: craft.assets.one(),
+        class: 'size-40',
+        transformMinWidth: 40,
+        transformMaxWidth: 80,
+        transformAutofillCount: 0,
+        ratio: 1/1,
+        sizes: '40px',
+      }) }}
     </div>
   </div>
+</div>
 
 {#
   Full Bleed Image
@@ -162,4 +157,3 @@
     transformAutofillCount: 1,
   }) }}
 </div>
-{% endblock %}

--- a/templates/parts-kit/page-hero/default.twig
+++ b/templates/parts-kit/page-hero/default.twig
@@ -1,11 +1,7 @@
-{% extends 'parts-kit/layout.twig' %}
-
 {% from '_components/page-hero' import PageHero %}
 
-{% block main %}
-  {{ PageHero({
-    image: craft.assets.one(),
-    title: 'Lorem ipsum dolor sit amet',
-    description: 'Cillum dolor nisi et sunt in in et ullamco eiusmod duis aute et fugiat excepteur. Sit irure consectetur anim do aliqua excepteur amet nulla magna enim proident incididunt ipsum.',
-  }) }}
-{% endblock %}
+{{ PageHero({
+  image: craft.assets.one(),
+  title: 'Lorem ipsum dolor sit amet',
+  description: 'Cillum dolor nisi et sunt in in et ullamco eiusmod duis aute et fugiat excepteur. Sit irure consectetur anim do aliqua excepteur amet nulla magna enim proident incididunt ipsum.',
+}) }}

--- a/templates/parts-kit/paginaton/default.twig
+++ b/templates/parts-kit/paginaton/default.twig
@@ -1,5 +1,3 @@
-{% extends 'parts-kit/layout.twig' %}
-
 {% from '_components/pagination' import Pagination %}
 
 {#
@@ -64,12 +62,10 @@ Example Usage:
   }) }}
 {% endset %}
 
-{% block main %}
-  <div class="p-64 flex flex-col gap-48">
-    {{ examples }}
-  </div>
+<div class="p-64 flex flex-col gap-48">
+  {{ examples }}
+</div>
 
-  <div class="dark bg-black p-64 flex flex-col gap-48">
-    {{ examples }}
-  </div>
-{% endblock %}
+<div class="dark bg-black p-64 flex flex-col gap-48">
+  {{ examples }}
+</div>

--- a/templates/parts-kit/tabs/default.twig
+++ b/templates/parts-kit/tabs/default.twig
@@ -1,23 +1,19 @@
-{% extends "parts-kit/layout.twig" %}
-
 {% from '_components/tabs' import Tabs %}
 
-{% block main %}
-  <div class="container py-64">
-    {{ Tabs({
-      tabs: [
-        { title: 'Tab 1', content: 'Content for Tab 1' },
-        { title: 'Tab 2', content: 'Content for Tab 2' },
-      ],
-    }) }}
-  </div>
+<div class="container py-64">
+  {{ Tabs({
+    tabs: [
+      { title: 'Tab 1', content: 'Content for Tab 1' },
+      { title: 'Tab 2', content: 'Content for Tab 2' },
+    ],
+  }) }}
+</div>
 
-  <div class="container py-64 bg-black dark">
-    {{ Tabs({
-      tabs: [
-        { title: 'Tab 1', content: 'Content for Tab 1' },
-        { title: 'Tab 2', content: 'Content for Tab 2' },
-      ],
-    }) }}
-  </div>
-{% endblock %}
+<div class="container py-64 bg-black dark">
+  {{ Tabs({
+    tabs: [
+      { title: 'Tab 1', content: 'Content for Tab 1' },
+      { title: 'Tab 2', content: 'Content for Tab 2' },
+    ],
+  }) }}
+</div>

--- a/templates/parts-kit/tag/default.twig
+++ b/templates/parts-kit/tag/default.twig
@@ -1,35 +1,31 @@
-{% extends "parts-kit/layout.twig" %}
-
 {% from '_components/tag' import Tag %}
 
 {% set variants = ['contained', 'outlined'] %}
 
 {% set sizes = ['sm', 'md', 'lg'] %}
 
-{% block main %}
-  {% for variant in variants %}
-    <div class="flex items-center gap-8 mb-48">
-      {% for size in sizes %}
-        {{ Tag({
-          text: 'Tag ' ~ size ~ ' ' ~ variant,
-          size: size,
-          variant: variant,
-        }) }}
+{% for variant in variants %}
+  <div class="flex items-center gap-8 mb-48">
+    {% for size in sizes %}
+      {{ Tag({
+        text: 'Tag ' ~ size ~ ' ' ~ variant,
+        size: size,
+        variant: variant,
+      }) }}
 
-        {{ Tag({
-          text: 'Tag ' ~ size ~ ' link',
-          size: size,
-          variant: variant,
-          href: '#TEST',
-        }) }}
+      {{ Tag({
+        text: 'Tag ' ~ size ~ ' link',
+        size: size,
+        variant: variant,
+        href: '#TEST',
+      }) }}
 
-        {{ Tag({
-          text: 'Tag ' ~ size ~ ' ' ~ variant,
-          size: size,
-          variant: variant,
-          icon: 'clock',
-        }) }}
-      {% endfor %}
-    </div>
-  {% endfor %}
-{% endblock %}
+      {{ Tag({
+        text: 'Tag ' ~ size ~ ' ' ~ variant,
+        size: size,
+        variant: variant,
+        icon: 'clock',
+      }) }}
+    {% endfor %}
+  </div>
+{% endfor %}

--- a/templates/parts-kit/video/default.twig
+++ b/templates/parts-kit/video/default.twig
@@ -1,17 +1,13 @@
-{% extends 'parts-kit/layout.twig' %}
-
 {% from '_components/video' import Video %}
 
-{% block main %}
-  <div class="max-w-prose mx-auto">
+<div class="max-w-prose mx-auto">
 
-    {{ Video({
-      source: 'https://www.youtube.com/embed/lJIrF4YjHfQ',
-      class: 'mb-24',
-    }) }}
+  {{ Video({
+    source: 'https://www.youtube.com/embed/lJIrF4YjHfQ',
+    class: 'mb-24',
+  }) }}
 
-    <p>
-      Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. <a href="#">Focusable Content After Video</a>
-    </p>
-  </div>
-{% endblock %}
+  <p>
+    Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos. <a href="#">Focusable Content After Video</a>
+  </p>
+</div>


### PR DESCRIPTION
- https://github.com/vigetlabs/craft-site-starter/pull/123
    - **https://github.com/vigetlabs/craft-site-starter/pull/124** 👈 You are here
    
----

This PR shows the template changes caused by this update to the Parts Kit  Plugin 

- https://github.com/vigetlabs/craft-parts-kit/pull/12

The goal is to eliminate boilerplate & nesting in our parts examples. 

📄  Recommend viewing with whitespace changes hidden. 