### PR TITLE
Automate repo verification

### DIFF
--- a/.claude/skills/verify-create-project/SKILL.md
+++ b/.claude/skills/verify-create-project/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: verify-create-project
+description: Runs the full "Getting Started" flow from the README to verify that `composer create-project` works correctly with the current branch.
+disable-model-invocation: true
+---
+
+## Inputs
+
+Ask the user for **both** of the following before starting:
+
+1. **Branch name** — which branch/version to test with `composer create-project`. The AI agent will convert branch name to Composer's `dev-<branch>` format, e.g. branch `jp/create-project-flags` becomes `dev-jp/create-project-flags`, branch `5.x` becomes `5.x-dev`). Note: for branches that look like version numbers (e.g. `5.x`), Composer uses `5.x-dev`; for all other branches, Composer uses `dev-<branch-name>`.
+2. **Directory path** — where the test project should be created. The directory must not already exist — the script will create it. Suggest `../craft-starter-test-<YYYY-MM-DD>` as a default.
+
+## Test Credentials
+
+- **Email:** admin@example.com
+- **Username:** admin
+- **Password:** password123
+
+Remember these — you'll need them to log in and verify the install.
+
+## Failure policy
+
+**Stop immediately on any unexpected result.** Every step below has explicit success criteria. If any step produces a non-zero exit code, unexpected output, missing files, incorrect values, or any other deviation from what is described — **stop execution, report exactly what went wrong (including full command output), and ask the user how to proceed.** Do not attempt to fix, retry, or work around failures automatically.
+
+This includes but is not limited to:
+- Commands exiting with non-zero status
+- Docker daemon not running
+- DDEV not installed or not responding
+- Vite or front-end builds not working.
+- Files missing or containing unexpected values after a step
+- Network errors, timeouts, or TLS failures
+- Browser pages returning errors (500, 502, connection refused, etc.)
+
+## Prerequisites
+
+Before starting, verify these prerequisites. **Stop and report if any fail:**
+
+1. **Docker is running:** Run `docker info` and confirm it exits successfully. If it fails, stop — the Docker daemon is not running.
+2. **DDEV is installed:** Run `ddev version` and confirm it exits successfully. If it fails, stop — DDEV is not installed.
+
+## Steps
+
+### 1. Create the test directory
+
+```bash
+mkdir -p <user-provided-directory>
+```
+
+Verify the directory was created and is empty (`ls -A` should produce no output). If it already contains files, **stop and ask the user what to do.**
+
+### 2. Run composer create-project via Docker
+
+From inside the test directory, run:
+
+```bash
+docker run --rm -it -v "$PWD":/app -v ${COMPOSER_HOME:-$HOME/.composer}:/tmp -e PROJECT_NAME="Test Project" -e PROJECT_SLUG="test-project" composer create-project viget/craft-site-starter=<composer-version> ./ --ignore-platform-reqs
+```
+
+Replace `<composer-version>` with the Composer version string derived from the user's chosen branch (see Inputs above).
+
+**Important:** The `-e PROJECT_NAME` and `-e PROJECT_SLUG` environment variables enable non-interactive mode in the post-create-project script, so no user input is required.
+
+Wait for this to complete. It may take a few minutes. **Verify it exits with code 0.** If it exits with any other code, **stop and report the full output.**
+
+### 3. Verify post-create-project changes
+
+After the create-project command finishes, verify **all** of the following. If **any** check fails, **stop and report all discrepancies** before proceeding:
+
+#### 3a. DDEV config
+
+- `.ddev/config.yaml` should have `name: test-project` (not `viget-craft-starter`)
+
+#### 3b. DDEV environment
+
+- `.ddev/.env.web` should have `PRIMARY_SITE_URL="https://test-project.ddev.site"` (not `viget-craft-starter.ddev.site`)
+
+#### 3c. package.json and package-lock.json
+
+- `package.json` should have `"name": "test-project"` (not `viget-craft-starter`)
+- `package-lock.json` should have `"name": "test-project"` (not `viget-craft-starter`)
+
+#### 3d. Project config — name replacements
+
+The string `Viget Craft Starter` should have been replaced with `Test Project` in **every** file under `config/project/`. Verify by grepping the entire `config/project/` directory for `Viget Craft Starter` — **there should be zero matches.** Specifically check:
+
+- `config/project/project.yaml` `email.fromName` should be `'Test Project'` (not `'Viget Craft Starter'`)
+- `config/project/project.yaml` `system.name` should be `'Test Project'` (not `'Viget Craft Starter'`)
+- `config/project/project.yaml` `meta.__names__` entries that previously said `Viget Craft Starter` should now say `Test Project`
+- The site group file in `config/project/siteGroups/` should have `name: 'Test Project'`
+- The site file in `config/project/sites/` should have `name: 'Test Project'`
+
+#### 3e. Project config — license keys removed
+
+- `config/project/project.yaml` should have **no** `licenseKey: REPLACE` entries. The `licenseKey` lines with value `REPLACE` should have been removed entirely (not replaced with a different value — the whole line should be gone).
+
+#### 3f. composer.json cleanup
+
+- The `composer.json` should no longer have a `post-create-project-cmd` script
+- The `composer.json` should no longer have a `name` field
+- The `composer.json` should no longer have a `license` field
+- The `composer.json` should no longer have a `type` field
+
+#### 3g. composer-scripts directory deleted
+
+- The `composer-scripts/` directory should **not exist** at all
+
+#### 3h. .env file created
+
+- A `.env` file should exist in the project root (copied from `.env.example.dev` during the create-project process)
+
+#### 3i. .gitignore — starter-only block removed
+
+- `.gitignore` should **not** contain `# BEGIN-STARTER-ONLY` or `# END-STARTER-ONLY`
+- `.gitignore` should **not** contain `config/license.key` (that line was inside the starter-only block)
+
+#### 3j. phpstan.neon — scanFiles removed
+
+- `phpstan.neon` should **not** contain a `scanFiles` section or any reference to `composer-scripts/ScriptHelpers.php`
+
+### 4. Start DDEV
+
+```bash
+ddev start
+```
+
+Wait for DDEV to fully start. This includes the post-start hooks (composer install, npm install, vite build). **Verify the command exits with code 0.** If it fails, **stop and report the full output.**
+
+### 5. Install Craft
+
+```bash
+ddev craft install --interactive=0 --email=admin@example.com --username=admin --password=password123
+```
+
+**Verify the command exits with code 0.** If it fails, **stop and report the full output.**
+
+### 6. Verify the site in the browser
+
+Use the browser tools to verify the installation. **If any check fails, stop and report the failure before continuing to the next check:**
+
+1. Navigate to `https://test-project.ddev.site` and verify the homepage loads (should not be a 500 error, connection refused, or blank page)
+2. Navigate to `https://test-project.ddev.site/admin` and log in with:
+   - **Username:** admin
+   - **Password:** password123
+3. Verify the Craft admin dashboard loads successfully
+4. Check that the site name shows "Test Project" (not "Viget Craft Starter")
+
+### 7. Report results
+
+Summarize the verification results:
+
+- Whether prerequisites passed (Docker, DDEV)
+- Whether create-project completed successfully
+- Whether file replacements were correct
+- Whether DDEV started without errors
+- Whether Craft installed successfully
+- Whether the frontend loaded
+- Whether the admin panel was accessible
+- Any warnings or issues encountered
+
+**Do NOT clean up the test directory** — leave it for manual inspection.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Viget's Craft CMS Starter
 
-Our Craft Site Starter is a quick way to spin up a new Craft CMS project. It's pre-configured with top-notch building tooling, common plugins and starter components based on [Blueprint](https://github.com/vigetlabs/blueprint).
+Our Craft Site Starter is a quick way to spin up a new Craft CMS project. It's pre-configured with top-notch build tooling, common plugins and starter components based on [Blueprint](https://github.com/vigetlabs/blueprint).
 
 If you're a designer or developer at Viget working on a new project, view our [Building with Craft Site Starter](docs/building-with-site-starter.md) guide for more information.
 
@@ -42,7 +42,7 @@ If you're a designer or developer at Viget working on a new project, view our [B
    composer create-project viget/craft-site-starter=^5.0.0 ./ --ignore-platform-reqs
    ```
 
-   If you'd rather not set up PHP, you can create the project with a desposable Docker
+   If you'd rather not set up PHP, you can create the project with a disposable Docker
    image ([Thanks nystudio107](https://nystudio107.com/blog/dock-life-using-docker-for-all-the-things)).
 
    ```shell
@@ -58,23 +58,23 @@ If you're a designer or developer at Viget working on a new project, view our [B
 
 # Plugins
 
-This starter includes common plugins that we use on most of our sites. This provides consistency and familiarly between
+This starter includes common plugins that we use on most of our sites. This provides consistency and familiarity between
 client projects. You may not need every plugin, but avoid
 replacing standard plugins with similar alternatives (unless absolutely necessary).
 
-| Name                                                              | Composer                          | Usage                                                                                                                                                                               | Year 1 Price | Renewal Price |
-| ----------------------------------------------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ------------- |
-| [Amazon S3](https://plugins.craftcms.com/aws-s3)                  | `craftcms/aws-s3`                 | This plugin integrates Craft CMS and Amazon S3 cloud storage service.                                                                                                               | Free         | Free          |
-| [Autocomplete](https://github.com/nystudio107/craft-autocomplete) | `nystudio107/craft-autocomplete`  | Provides Twig template IDE autocomplete of Craft CMS & plugin variables. Requires the [PHPStorm Symphony Support Plugin](https://plugins.jetbrains.com/plugin/7219-symfony-support) | Free         | Free          |
-| [CKEditor](https://plugins.craftcms.com/ckeditor)                 | `craftcms/ckeditor`               | Craft CMS’s official rich text plugin                                                                                                                                               | Free         | Free          |
-| [Classnames](https://plugins.craftcms.com/classnames)             | `viget/craft-classnames`          | Conditionally join css class names together in Twig                                                                                                                                 | Free         | Free          |
-| [Empty Coalesce](https://plugins.craftcms.com/empty-coalesce)     | `nystudio107/craft-emptycoalesce` | Adds the `???` operator to Twig that will return the first thing that is defined, not null, and not empty.                                                                          | Free         | Free          |
-| [Imager X](https://plugins.craftcms.com/imager-x)                 | `spacecatninja/imager-x`          | Image optimization and Imgix connector. Provides useful Twig shortcuts for generating transforms and placeholders.                                                                  | $99.00       | $59.00        |
-| [Navigation](https://plugins.craftcms.com/navigation)             | `verbb/navigation`                | Simplifies management of complex navigation groups (main menus, footer menus, etc.)                                                                                                 | $19.00       | $5.00         |
-| [Retour](https://plugins.craftcms.com/retour)                     | `nystudio107/craft-retour`        | Provides an Craft admin UI to set up redirects. Will automatically create redirects when URLs of entries change.                                                                    | $59.00       | $29.00        |
-| [SEOMatic](https://plugins.craftcms.com/seomatic)                 | `nystudio107/craft-seomatic`      | A turnkey SEO plugin that follows [modern SEO best practices](https://nystudio107.com/blog/modern-seo-snake-oil-vs-substance).                                                      | $99.00       | $49.00        |
-| [Vite](https://plugins.craftcms.com/vite)                         | `nystudio107/craft-vite`          | Loads front-end files that are compiled by Vite.                                                                                                                                    | Free         | Free          |
-| [Expanded Singles](https://plugins.craftcms.com/expanded-singles) | `verbb/expanded-singles`          | Change the entries index sidebar to list all singles, rather than grouping them under a 'Singles' menu item.                                                                        | Free         | Free          |
+| Name                                                              | Composer                          | Usage                                                                                                                                                                              | Year 1 Price | Renewal Price |
+| ----------------------------------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ------------- |
+| [Amazon S3](https://plugins.craftcms.com/aws-s3)                  | `craftcms/aws-s3`                 | This plugin integrates Craft CMS and Amazon S3 cloud storage service.                                                                                                              | Free         | Free          |
+| [Autocomplete](https://github.com/nystudio107/craft-autocomplete) | `nystudio107/craft-autocomplete`  | Provides Twig template IDE autocomplete of Craft CMS & plugin variables. Requires the [PHPStorm Symfony Support Plugin](https://plugins.jetbrains.com/plugin/7219-symfony-support) | Free         | Free          |
+| [CKEditor](https://plugins.craftcms.com/ckeditor)                 | `craftcms/ckeditor`               | Craft CMS’s official rich text plugin                                                                                                                                              | Free         | Free          |
+| [Classnames](https://plugins.craftcms.com/classnames)             | `viget/craft-classnames`          | Conditionally join css class names together in Twig                                                                                                                                | Free         | Free          |
+| [Empty Coalesce](https://plugins.craftcms.com/empty-coalesce)     | `nystudio107/craft-emptycoalesce` | Adds the `???` operator to Twig that will return the first thing that is defined, not null, and not empty.                                                                         | Free         | Free          |
+| [Imager X](https://plugins.craftcms.com/imager-x)                 | `spacecatninja/imager-x`          | Image optimization and Imgix connector. Provides useful Twig shortcuts for generating transforms and placeholders.                                                                 | $99.00       | $59.00        |
+| [Navigation](https://plugins.craftcms.com/navigation)             | `verbb/navigation`                | Simplifies management of complex navigation groups (main menus, footer menus, etc.)                                                                                                | $19.00       | $5.00         |
+| [Retour](https://plugins.craftcms.com/retour)                     | `nystudio107/craft-retour`        | Provides a Craft admin UI to set up redirects. Will automatically create redirects when URLs of entries change.                                                                    | $59.00       | $29.00        |
+| [SEOMatic](https://plugins.craftcms.com/seomatic)                 | `nystudio107/craft-seomatic`      | A turnkey SEO plugin that follows [modern SEO best practices](https://nystudio107.com/blog/modern-seo-snake-oil-vs-substance).                                                     | $99.00       | $49.00        |
+| [Vite](https://plugins.craftcms.com/vite)                         | `nystudio107/craft-vite`          | Loads front-end files that are compiled by Vite.                                                                                                                                   | Free         | Free          |
+| [Expanded Singles](https://plugins.craftcms.com/expanded-singles) | `verbb/expanded-singles`          | Change the entries index sidebar to list all singles, rather than grouping them under a 'Singles' menu item.                                                                       | Free         | Free          |
 
 # Contribute to this starter
 

--- a/composer-scripts/post-create-project.php
+++ b/composer-scripts/post-create-project.php
@@ -110,3 +110,15 @@ ScriptHelpers::replaceFileText(
     pattern: "/# BEGIN-STARTER-ONLY\X*# END-STARTER-ONLY/m",
     replacement: '',
 );
+
+/**
+ * phpstan.neon
+ * Remove the scanFiles entry for composer-scripts/ since that directory
+ * is deleted after create-project runs.
+ */
+
+ScriptHelpers::replaceFileText(
+    filePath: "$cwd/phpstan.neon",
+    pattern: "/\n    scanFiles:\n        - composer-scripts\/ScriptHelpers\.php/",
+    replacement: '',
+);

--- a/composer-scripts/post-create-project.php
+++ b/composer-scripts/post-create-project.php
@@ -9,23 +9,40 @@ require_once 'vendor/autoload.php';
 $cwd = getcwd();
 
 /**
- * Prompt the user for input
+ * Prompt the user for input or accept environment variables.
  */
-$projectName = Console::prompt('What is the name of your project (Example: My Client Name)? ', [
-    'required' => true,
-]);
+$envProjectName = getenv('PROJECT_NAME') ?: null;
+$envProjectSlug = getenv('PROJECT_SLUG') ?: null;
 
-Console::output("Great! We'll use the name: $projectName");
+if ($envProjectName) {
+    // Non-interactive mode
+    $projectName = $envProjectName;
+    $projectSlug = $envProjectSlug
+        ? StringHelper::toKebabCase($envProjectSlug)
+        : StringHelper::toKebabCase($projectName);
 
-$suggestedProjectSlug = StringHelper::toKebabCase($projectName);
+    Console::output("Using project name: $projectName");
+    Console::output("Using project slug: $projectSlug");
+} else {
+    // Interactive mode (current behavior, unchanged)
+    $projectName = Console::prompt('What is the name of your project (Example: My Client Name)? ', [
+        'required' => true,
+    ]);
 
-$projectSlugPrompt = Console::prompt("Customize the project slug? This controls the DDEV URL, etc.", [
-    'default' => $suggestedProjectSlug,
-]);
+    Console::output("Great! We'll use the name: $projectName");
 
-$projectSlug = !empty(trim($projectSlugPrompt)) ? StringHelper::toKebabCase($projectSlugPrompt) : $suggestedProjectSlug;
+    $suggestedProjectSlug = StringHelper::toKebabCase($projectName);
 
-Console::output("Great! We'll use $projectSlug");
+    $projectSlugPrompt = Console::prompt("Customize the project slug? This controls the DDEV URL, etc.", [
+        'default' => $suggestedProjectSlug,
+    ]);
+
+    $projectSlug = !empty(trim($projectSlugPrompt))
+        ? StringHelper::toKebabCase($projectSlugPrompt)
+        : $suggestedProjectSlug;
+
+    Console::output("Great! We'll use $projectSlug");
+}
 
 /**
  * Update DDEV config

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,5 @@ parameters:
         - config
     scanDirectories:
         - storage/runtime/compiled_classes
+    scanFiles:
+        - composer-scripts/ScriptHelpers.php


### PR DESCRIPTION
## Summary

Adds support for automated, non-interactive `composer create-project` runs and a Claude Code skill that exercises the full Getting Started flow end-to-end.

### Changes

- **Non-interactive mode for `composer create-project`** — `PROJECT_NAME` and `PROJECT_SLUG` env vars bypass interactive prompts, enabling scripted/CI verification
- **PHPStan config updated** to properly check `composer-scripts/`
- **Typo fixes** in README / scripts
- **New `verify-create-project` skill** — runs `composer create-project` via Docker, starts DDEV, installs Craft, and verifies the site in a browser; validates all post-create-project transformations (name replacements, license key removal, config cleanup, `.gitignore` pruning); halts on any failure with full output

### Intent

The `post-create-project` script has a lot of moving parts (string replacements, file deletions, config rewrites) and previously could only be verified manually. These changes make it possible to have an LLM automate some of those checks in a "fuzzy" way. 