### PR TITLE
[#142] Exclude node_modules, storage, cpresources, and vendor from Mutagen sync

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -37,6 +37,13 @@ web_extra_daemons:
     command: 'npm install && npm run build && npm run dev'
     directory: /var/www/html
 disable_upload_dirs_warning: true
+upload_dirs:
+  # https://docs.ddev.com/en/stable/users/install/performance/#mutagen:~:text=Large%20node_modules%20can%20cause%20cause%20slow%20sync%20times
+  - node_modules
+  - storage
+  - web/cpresources
+  - vendor
+
 # Key features of ddev's config.yaml:
 
 # name: <projectname> # Name of the project, automatically provides


### PR DESCRIPTION
## Summary

Configures `upload_dirs` in DDEV to exclude high-churn and large directories from Mutagen file syncing. DDEV bind-mounts these paths instead, which keeps them accessible on the host (IDE navigation still works) while removing them from Mutagen's sync workload.

Excluded directories:

- `node_modules` — large dependency tree, frequent churn during installs
- `storage` — Craft runtime caches, logs, backups, and other generated content
- `web/cpresources` — auto-published control panel assets, regenerated on demand
- `vendor` — Composer dependencies, large file count

See: https://docs.ddev.com/en/stable/users/install/performance/#mutagen:~:text=Large%20node_modules%20can%20cause%20cause%20slow%20sync%20times

## Notes

After pulling, run `ddev restart` to apply the bind-mount changes.