### PR TITLE
[#117] Switch icon system to a Vite-built SVG spritemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ If you're a designer or developer at Viget working on a new project, view our [B
 - A fully accessible header and navigation
 - A simple Matrix Field based block editor
 
+## Icons
+
+Icons are bundled into a single SVG spritemap at build time by [@spiriit/vite-plugin-svg-spritemap](https://github.com/SpiriitLabs/vite-plugin-svg-spritemap) and referenced via `<use href>` from the `Icon` macro in `templates/_components/icon.twig`.
+
+To add an icon, drop an SVG into `src/icons/` and run `npm run build` (HMR does not work currently)
+
 # Getting Started
 
 ## Create Project

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you're a designer or developer at Viget working on a new project, view our [B
 
 Icons are bundled into a single SVG spritemap at build time by [@spiriit/vite-plugin-svg-spritemap](https://github.com/SpiriitLabs/vite-plugin-svg-spritemap) and referenced via `<use href>` from the `Icon` macro in `templates/_components/icon.twig`.
 
-To add an icon, drop an SVG into `src/icons/` and run `npm run build` (HMR does not work currently)
+To add an icon, drop an SVG into `src/icons/` and run `npm run build`
 
 # Getting Started
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
+        "@spiriit/vite-plugin-svg-spritemap": "^6.0.0",
         "@tailwindcss/postcss": "^4.0.0",
         "cssnano": "^7.0.6",
         "eslint-config-prettier": "^10.0.2",
@@ -24,8 +25,7 @@
         "postcss-pxtorem": "^6.1.0",
         "prettier": "^3.5.2",
         "tailwindcss": "^4.0.0",
-        "vite": "^6.3.6",
-        "vite-plugin-static-copy": "^2.3.2"
+        "vite": "^6.3.6"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -755,44 +755,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
@@ -1143,6 +1105,69 @@
         "win32"
       ]
     },
+    "node_modules/@spiriit/vite-plugin-svg-spritemap": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@spiriit/vite-plugin-svg-spritemap/-/vite-plugin-svg-spritemap-6.0.0.tgz",
+      "integrity": "sha512-zCxwZQmW9ZRGRsmzOWcwkObkUkLbUBv8mG4VEnAGHtQPijYleq5rI5hCvVEHFsXaWFKnqB4hBHQURXDzrkdENg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.8",
+        "hash-sum": "^2.0.0",
+        "mini-svg-data-uri": "^1.4.4",
+        "picomatch": "^4.0.3",
+        "tinyglobby": "^0.2.15"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "@oxvg/napi": "^0.0.4-1",
+        "@oxvg/napi-darwin-arm64": "^0.0.4-1",
+        "@oxvg/napi-darwin-x64": "^0.0.4-1",
+        "@oxvg/napi-linux-x64-gnu": "^0.0.4-1",
+        "@oxvg/napi-win32-x64-msvc": "^0.0.4-1",
+        "svgo": "^4.0.0",
+        "vite": "^6.0.0 || ^7.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@oxvg/napi": {
+          "optional": true
+        },
+        "@oxvg/napi-darwin-arm64": {
+          "optional": true
+        },
+        "@oxvg/napi-darwin-x64": {
+          "optional": true
+        },
+        "@oxvg/napi-linux-x64-gnu": {
+          "optional": true
+        },
+        "@oxvg/napi-win32-x64-msvc": {
+          "optional": true
+        },
+        "svgo": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@spiriit/vite-plugin-svg-spritemap/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
@@ -1452,6 +1477,16 @@
       "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
       "license": "MIT"
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1546,20 +1581,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1582,19 +1603,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/boolbase": {
@@ -1710,44 +1718,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/cli-cursor": {
@@ -2430,36 +2400,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2475,16 +2415,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -2563,21 +2493,6 @@
         "tabbable": "^6.4.0"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2653,6 +2568,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/hash-sum": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -2701,25 +2623,13 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2743,6 +2653,7 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2813,19 +2724,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/jsonfile": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
-      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -3281,16 +3179,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -3329,6 +3217,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
       }
     },
     "node_modules/minimatch": {
@@ -3388,16 +3286,6 @@
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -3505,19 +3393,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-map": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4115,40 +3990,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -4180,17 +4021,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
       }
     },
     "node_modules/rfdc": {
@@ -4243,30 +4073,6 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.2",
         "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/sax": {
@@ -4554,16 +4360,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -4686,26 +4482,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-plugin-static-copy": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.3.2.tgz",
-      "integrity": "sha512-iwrrf+JupY4b9stBttRWzGHzZbeMjAHBhkrn67MNACXJVjEMRpCI10Q3AkxdBkl45IHaTfw/CNVevzQhP7yTwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.11",
-        "fs-extra": "^11.1.0",
-        "p-map": "^7.0.3",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/vite/node_modules/fdir": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
+    "@spiriit/vite-plugin-svg-spritemap": "^6.0.0",
     "@tailwindcss/postcss": "^4.0.0",
     "cssnano": "^7.0.6",
     "eslint-config-prettier": "^10.0.2",
@@ -23,8 +24,7 @@
     "postcss-pxtorem": "^6.1.0",
     "prettier": "^3.5.2",
     "tailwindcss": "^4.0.0",
-    "vite": "^6.3.6",
-    "vite-plugin-static-copy": "^2.3.2"
+    "vite": "^6.3.6"
   },
   "dependencies": {
     "@alpinejs/collapse": "^3.14.1",

--- a/templates/_components/icon.twig
+++ b/templates/_components/icon.twig
@@ -1,5 +1,7 @@
 {#
-Inlines the SVG markup directly into the page.
+References icons from a Vite-generated SVG sprite sheet.
+
+Drop a new file in `src/icons/` and it's automatically available by name.
 
 Provides icon size props so you don't have to remember to pass
 `.size-xyz` every time you want to use your icon system.
@@ -31,8 +33,14 @@ By setting size to `none` you can add arbitrary size classes to the icon.
 
   {% set sizeClass = sizeConfig[size] ?? sizeConfig.md %}
 
-  {{ svg('@webroot/dist/assets/icons/' ~ name ~ '.svg')|attr({
+  {# `<use href>` enforces same-origin, so we reference the built spritemap from
+     `web/dist/` even in dev. `craft.vite.entry()` resolves the manifest URL for
+     non-script assets, avoiding the dev server's cross-origin URL.
+     Adding new icons in `src/icons/` requires an `npm run build` to take effect. #}
+  <svg {{ attr({
     class: cx(sizeClass, class),
     'aria-hidden': ariaHidden ? 'true' : null,
-  }) }}
+  }) }}>
+    <use href="{{ craft.vite.entry('spritemap.svg') }}#sprite-{{ name }}"></use>
+  </svg>
 {% endmacro %}

--- a/templates/_components/icon.twig
+++ b/templates/_components/icon.twig
@@ -33,14 +33,14 @@ By setting size to `none` you can add arbitrary size classes to the icon.
 
   {% set sizeClass = sizeConfig[size] ?? sizeConfig.md %}
 
-  {# `<use href>` enforces same-origin, so we reference the built spritemap from
-     `web/dist/` even in dev. `craft.vite.entry()` resolves the manifest URL for
-     non-script assets, avoiding the dev server's cross-origin URL.
-     Adding new icons in `src/icons/` requires an `npm run build` to take effect. #}
+  {# In dev the plugin's `injectSVGOnDev` injects the spritemap into the page,
+     so `<use href="#sprite-X">` resolves locally and HMR works.
+     In prod we reference the built same-origin spritemap to avoid HTML bloat. #}
+  {% set spritemapUrl = craft.vite.devServerRunning() ? '' : craft.vite.entry('spritemap.svg') %}
   <svg {{ attr({
     class: cx(sizeClass, class),
     'aria-hidden': ariaHidden ? 'true' : null,
   }) }}>
-    <use href="{{ craft.vite.entry('spritemap.svg') }}#sprite-{{ name }}"></use>
+    <use href="{{ spritemapUrl }}#sprite-{{ name }}"></use>
   </svg>
 {% endmacro %}

--- a/templates/_components/icon.twig
+++ b/templates/_components/icon.twig
@@ -20,8 +20,11 @@ By setting size to `none` you can add arbitrary size classes to the icon.
   {# @var string|null class #}
   {% set class = props.class ?? null %}
 
+  {# @var string|null title #}
+  {% set title = props.title ?? null %}
+
   {# @var bool ariaHidden #}
-  {% set ariaHidden = props.ariaHidden ?? true %}
+  {% set ariaHidden = props.ariaHidden ?? (title is null) %}
 
   {# Computed values #}
   {% set sizeConfig = {
@@ -33,6 +36,8 @@ By setting size to `none` you can add arbitrary size classes to the icon.
 
   {% set sizeClass = sizeConfig[size] ?? sizeConfig.md %}
 
+  {% set titleId = title ? 'icon-title-' ~ random() : null %}
+
   {# In dev the plugin's `injectSVGOnDev` injects the spritemap into the page,
      so `<use href="#sprite-X">` resolves locally and HMR works.
      In prod we reference the built same-origin spritemap to avoid HTML bloat. #}
@@ -40,7 +45,10 @@ By setting size to `none` you can add arbitrary size classes to the icon.
   <svg {{ attr({
     class: cx(sizeClass, class),
     'aria-hidden': ariaHidden ? 'true' : null,
+    'aria-labelledby': titleId,
+    role: title ? 'img' : null,
   }) }}>
+    {% if title %}<title id="{{ titleId }}">{{ title }}</title>{% endif %}
     <use href="{{ spritemapUrl }}#sprite-{{ name }}"></use>
   </svg>
 {% endmacro %}

--- a/templates/_partials/head.twig
+++ b/templates/_partials/head.twig
@@ -10,3 +10,7 @@
   {% endif %}
 
   {{ craft.vite.script('src/js/app.js', false) }}
+
+  {% if craft.vite.devServerRunning() %}
+    {{ craft.vite.script('@vite-plugin-svg-spritemap/client', false) }}
+  {% endif %}

--- a/templates/parts-kit/icons/default.twig
+++ b/templates/parts-kit/icons/default.twig
@@ -33,5 +33,14 @@
       name: 'arrow-right',
       ariaHidden: false,
     }) }}
+
+    <p class="text-sm text-gray-500">
+      Pass a <code>title</code> to render an SVG <code>&lt;title&gt;</code> element. This automatically exposes the icon to screen readers.
+    </p>
+
+    {{ Icon({
+      name: 'arrow-right',
+      title: 'Next page',
+    }) }}
   </div>
 {% endfor %}

--- a/vite.config.js
+++ b/vite.config.js
@@ -32,6 +32,7 @@ export default defineConfig(({ command }) => {
     plugins: [
       VitePluginSvgSpritemap('./src/icons/*.svg', {
         output: { name: 'spritemap.svg' },
+        injectSVGOnDev: true, // Used only in dev mode for HMR
       }),
     ],
   }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import { viteStaticCopy } from 'vite-plugin-static-copy'
+import VitePluginSvgSpritemap from '@spiriit/vite-plugin-svg-spritemap'
 import process from 'node:process'
 
 // Matches ddev web_extra_exposed_ports.https_port
@@ -30,8 +30,8 @@ export default defineConfig(({ command }) => {
       },
     },
     plugins: [
-      viteStaticCopy({
-        targets: [{ src: 'src/icons/**/*', dest: './assets/icons' }],
+      VitePluginSvgSpritemap('./src/icons/*.svg', {
+        output: { name: 'spritemap.svg' },
       }),
     ],
   }


### PR DESCRIPTION
## Summary

Replaces the previous inline-per-render icon approach (Twig's `svg()` function pulling individual files from `web/dist/assets/icons/`) with a single Vite-built SVG spritemap, referenced via `<use href>` from the existing `Icon` macro. The macro's prop API is unchanged — all existing call sites work as-is.

Inspired by Chris Coyier's [SVG `use` with External Reference, Take 2](https://css-tricks.com/svg-use-with-external-reference-take-2/) (CSS-Tricks, 2015).

## Why

**Performance**
- The spritemap is a single, cacheable file shared across every page — repeat visits cost ~0 bytes for icons after the first download.
- HTML payload shrinks: each icon use is now ~80 bytes of `<svg><use>` markup instead of the full inlined SVG, which previously got duplicated for every icon usage on every page.
- Vite emits a hashed filename (`spritemap.{hash}.svg`), so cache-busting is automatic.

**CSS / DX**
- Single-color cascading still works — `color` / `fill` cascades through `<use>`, so Tailwind text utilities continue to color icons.
- The `Icon` macro remains the single entry point for sizing (`sm` / `md` / `lg` / `none`), so callers don't have to remember `.size-xyz` classes.
- Adding an icon: drop a file in `src/icons/`, no Twig changes needed.

## HMR

Editing or adding SVGs in `src/icons/` updates the live page without a reload. Three pieces:

1. **Plugin option** — `injectSVGOnDev: true` in `vite.config.js` makes the plugin inject the live spritemap as an inline `<svg>` into the document on dev.
2. **Macro switch** — in dev, the `Icon` macro emits `<use href="#sprite-{name}">` (no URL) so the reference resolves against the in-page injected `<symbol>`. In prod, it falls back to the same-origin built file (`<use href="…/spritemap.{hash}.svg#sprite-{name}">`).
3. **HMR client** — `templates/_partials/head.twig` loads `@vite-plugin-svg-spritemap/client` in dev so the plugin can patch the injected `<symbol>` content in place when an SVG file changes.

Why the dev/prod split? `<use href>` enforces same-origin, and the dev server runs on a different port (3000 vs 443), so an external dev URL would be blocked by the browser. Inlining the spritemap on dev sidesteps that.

See the [plugin's backend integration guide](https://spiriitlabs.github.io/vite-plugin-svg-spritemap/guide/backend-integration.html) for the upstream pattern.

## Trade-off (called out in the article)

- Individual inner shapes can't be styled from page CSS — the `<use>`-rendered Shadow DOM is opaque to selectors. The previous inline approach allowed this; nothing currently relies on it.

## Bonus: optional `title` prop on `Icon` (#118)

  The `Icon` macro now accepts a `title` prop. When passed, it renders an
  SVG `<title>` element and exposes the icon to screen readers via
  `role="img"` + `aria-labelledby`. When omitted, the icon stays
  `aria-hidden` — existing call sites are unchanged.

## Test plan

- [ ] `npm run build` emits `web/dist/assets/spritemap.{hash}.svg` and a manifest entry for `spritemap.svg`
- [ ] Parts Kit → Icons → Default renders all sizes (sm/md/lg) and the accessibility example
- [ ] Header, mobile nav, and footer logos render at correct dimensions
- [ ] Icon-bearing components (button, tag, accordion, dialog, alert-banner, card-icon, field-group, pagination) render correctly
- [ ] Icons cascade `currentColor` from parent text color
- [ ] Editing `src/icons/<name>.svg` in dev updates the rendered icon without a page reload