### PR TITLE
[#138] Remove custom php-local.ini

### DIFF
--- a/.ddev/php/php-local.ini
+++ b/.ddev/php/php-local.ini
@@ -1,3 +1,0 @@
-[PHP]
-display_errors = On
-error_reporting = ~E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED;


### PR DESCRIPTION
Craft 5.9 replaced the [stringy](https://github.com/danielstjules/Stringy) dependency, which was the source of the PHP 8.4 deprecation warnings the custom `.ddev/php/php-local.ini` was added to suppress (see d88690f). With stringy gone, the suppression is no longer needed.

## Test plan

- [ ] `ddev restart` and confirm the site boots without deprecation warnings in the logs or browser
- [ ] Hit a few CP pages (entries index, settings) and a few front-end pages