### PR TITLE
[#111] Align Button + link-aware component props with Craft conventions

### DIFF
--- a/templates/_blocks/_callToAction.twig
+++ b/templates/_blocks/_callToAction.twig
@@ -6,7 +6,7 @@
 {{ CallToAction({
   title: block.title,
   text: block.richTextSimple,
-  href: block.button.value,
+  url: block.button.value,
   buttonText: block.button.label ?? null,
-  newTab: block.button.target ?? null,
+  target: block.button.target ?? null,
 }) }}

--- a/templates/_blocks/_cardGrid.twig
+++ b/templates/_blocks/_cardGrid.twig
@@ -24,16 +24,16 @@
               md: '33vw',
               lg: '25vw',
             },
-            href: card.basicLink,
-            newTab: card.basicLink.target ?? null,
+            url: card.basicLink,
+            target: card.basicLink.target ?? null,
             title: card.title,
             description: card.description,
             headingLevel: cardHeadingLevel,
           }) }}
         {% case 'iconCard' %}
           {{ CardIcon({
-            href: card.basicLink,
-            newTab: card.basicLink.target ?? null,
+            url: card.basicLink,
+            target: card.basicLink.target ?? null,
             icon: card.icon.value,
             title: card.title,
             description: card.description,

--- a/templates/_components/button.twig
+++ b/templates/_components/button.twig
@@ -23,11 +23,17 @@
   {# @var bool iconOnly #}
   {% set iconOnly = props.iconOnly ?? false %}
 
-  {# @var string|null href #}
-  {% set href = props.href ?? null %}
+  {# @var string|null url #}
+  {% set url = props.url ?? null %}
 
-  {# @var bool newTab #}
-  {% set newTab = props.newTab ?? false %}
+  {# @var string|null target Pass '_blank' to open in a new tab. #}
+  {% set target = props.target ?? null %}
+
+  {# @var string|null ariaLabel #}
+  {% set ariaLabel = props.ariaLabel ?? null %}
+
+  {# @var bool|string|null download Pass true (or a filename) to set the download attribute. #}
+  {% set download = props.download ?? null %}
 
   {# @var string type #}
   {% set type = props.type ?? 'button' %}
@@ -41,16 +47,19 @@
   {# @var string|null text #}
   {% set text = props.text ?? null %}
 
-  {# Determine element type #}
-  {% set el = as ?? (href and not disabled ? 'a' : 'button') %}
-
   {# @var array attrs #}
   {% set attrs = props.attrs ?? {} %}
 
-  {% tag el with attrs | merge({
-    href: not disabled ? href : null,
-    target: newTab ? '_blank' : null,
-    rel: newTab ? 'noopener' : null,
+  {# Determine element type #}
+  {% set el = as ?? (url and not disabled ? 'a' : 'button') %}
+
+  {% tag el with {
+    ...attrs,
+    href: not disabled ? url : null,
+    target: target,
+    rel: target == '_blank' ? 'noopener noreferrer' : null,
+    download: download,
+    'aria-label': ariaLabel ?? attrs['aria-label'] ?? null,
     disabled: disabled ? true : null,
     type: el == 'button' ? type : null,
     title: title,
@@ -63,7 +72,7 @@
       'btn-sm': size == 'sm',
       'btn-lg': size == 'lg',
     }, class),
-  }) %}
+  } %}
     {{ icon ? Icon({
       name: icon,
       size: size,

--- a/templates/_components/call-to-action.twig
+++ b/templates/_components/call-to-action.twig
@@ -9,14 +9,14 @@
   {# @var string|null text #}
   {% set text = props.text ?? null %}
 
-  {# @var string|null href #}
-  {% set href = props.href ?? null %}
+  {# @var string|null url #}
+  {% set url = props.url ?? null %}
 
   {# @var string|null buttonText #}
   {% set buttonText = props.buttonText ?? null %}
 
-  {# @var boolean|null newTab #}
-  {% set newTab = props.newTab ?? null %}
+  {# @var string|null target Pass '_blank' to open in a new tab. #}
+  {% set target = props.target ?? null %}
 
   {# @var string|null class #}
   {% set class = props.class ?? null %}
@@ -31,10 +31,10 @@
         <div class="max-w-[640px]">{{ text }}</div>
       {% endif %}
 
-      {% if href and buttonText %}
+      {% if url and buttonText %}
         {{ Button({
-          href,
-          newTab,
+          url,
+          target,
           text: buttonText,
         }) }}
       {% endif %}

--- a/templates/_components/card-icon.twig
+++ b/templates/_components/card-icon.twig
@@ -6,11 +6,11 @@
   {# @var string|null class #}
   {% set class = props.class ?? null %}
 
-  {# @var string|null href #}
-  {% set href = props.href ?? null %}
+  {# @var string|null url #}
+  {% set url = props.url ?? null %}
 
-  {# @var string|null newTab #}
-  {% set newTab = props.newTab ?? null %}
+  {# @var string|null target Pass '_blank' to open in a new tab. #}
+  {% set target = props.target ?? null %}
 
   {# @var string align #}
   {% set align = props.align ?? 'left' %}
@@ -28,7 +28,7 @@
   {% set description = props.description ?? null %}
 
   {# Computed values #}
-  {% set element = href ? 'a' : 'article' %}
+  {% set element = url ? 'a' : 'article' %}
   {% set headingElement = "h#{headingLevel}" %}
 
   {% tag element with {
@@ -36,8 +36,9 @@
       'items-start': align == 'left',
       'items-center text-center': align == 'center',
     }),
-    href: href,
-    target: href and newTab ? '_blank' : null,
+    href: url,
+    target: target,
+    rel: target == '_blank' ? 'noopener noreferrer' : null,
   } %}
     {% if icon %}
       <div class="flex size-48 items-center justify-center rounded-full bg-sky-200 text-black">

--- a/templates/_components/card-image.twig
+++ b/templates/_components/card-image.twig
@@ -7,11 +7,11 @@
   {# @var string|null class #}
   {% set class = props.class ?? null %}
 
-  {# @var string|null href #}
-  {% set href = props.href ?? null %}
+  {# @var string|null url #}
+  {% set url = props.url ?? null %}
 
-  {# @var bool newTab #}
-  {% set newTab = props.newTab ?? false %}
+  {# @var string|null target Pass '_blank' to open in a new tab. #}
+  {% set target = props.target ?? null %}
 
   {# @var craft\elements\Asset|null image #}
   {% set image = props.image ?? null %}
@@ -35,7 +35,7 @@
   {% set description = props.description ?? null %}
 
   {# Computed values #}
-  {% set element = href ? 'a' : 'article' %}
+  {% set element = url ? 'a' : 'article' %}
   {% set headingElement = "h#{headingLevel}" %}
 
   {% tag element with {
@@ -43,8 +43,9 @@
       'items-start': align == 'left',
       'items-center text-center': align == 'center',
     }),
-    href: href,
-    target: href and newTab ? '_blank' : null,
+    href: url,
+    target: target,
+    rel: target == '_blank' ? 'noopener noreferrer' : null,
   } %}
     {% if image %}
       {{ Image({

--- a/templates/_components/pagination.twig
+++ b/templates/_components/pagination.twig
@@ -66,7 +66,7 @@
     <ul class="flex items-center gap-16">
       <li>
         {{ Button({
-          href: prevUrl,
+          url: prevUrl,
           text: 'Previous',
           icon: 'arrow-left',
           variant: 'outlined',
@@ -117,7 +117,7 @@
 
       <li>
         {{ Button({
-          href: nextUrl,
+          url: nextUrl,
           text: 'Next',
           icon: 'arrow-right',
           variant: 'outlined',
@@ -146,7 +146,7 @@
   {% set currentPage = props.currentPage ?? null %}
 
   {{ Button({
-    href: url,
+    url: url,
     text: page,
     variant: page == currentPage ? 'contained' : 'subtle',
     size: size,

--- a/templates/_components/tag.twig
+++ b/templates/_components/tag.twig
@@ -15,8 +15,11 @@
   {# @var boolean clickable #}
   {% set clickable = props.clickable ?? false %}
 
-  {# @var string|null href #}
-  {% set href = props.href ?? null %}
+  {# @var string|null url #}
+  {% set url = props.url ?? null %}
+
+  {# @var string|null target Pass '_blank' to open in a new tab. #}
+  {% set target = props.target ?? null %}
 
   {# @var string|null class #}
   {% set class = props.class ?? null %}
@@ -33,21 +36,24 @@
   {# Computed values #}
 
   {# Determine element type #}
-  {% set el = as ?? (href ? 'a' : (clickable ? 'button' : 'span')) %}
+  {% set el = as ?? (url ? 'a' : (clickable ? 'button' : 'span')) %}
 
-  {% tag el with attrs|merge({
-    href: href,
+  {% tag el with {
+    ...attrs,
+    href: url,
+    target: target,
+    rel: target == '_blank' ? 'noopener noreferrer' : null,
     type: clickable and el == 'button' ? 'button' : null,
     class: cx('inline-flex items-center justify-center gap-4 rounded-xs text-center font-medium focus:outline-hidden focus-visible:ring-4', {
       'bg-sky-600 text-white dark:bg-sky-200 dark:text-sky-800': variant == 'contained',
-      'no-underline hover:bg-sky-700 focus-visible:bg-sky-700 focus-visible:ring-sky-600/50 active:bg-sky-800 dark:hover:bg-sky-50 dark:focus-visible:bg-sky-50 dark:focus-visible:ring-white/50 dark:active:bg-sky-100': variant == 'contained' and (href or clickable),
+      'no-underline hover:bg-sky-700 focus-visible:bg-sky-700 focus-visible:ring-sky-600/50 active:bg-sky-800 dark:hover:bg-sky-50 dark:focus-visible:bg-sky-50 dark:focus-visible:ring-white/50 dark:active:bg-sky-100': variant == 'contained' and (url or clickable),
       'border border-sky-600 bg-transparent text-sky-600 dark:border-white dark:text-white': variant == 'outlined',
-      'hover:border-sky-700 hover:bg-sky-100 hover:text-sky-700 focus-visible:border-sky-700 focus-visible:bg-sky-100 focus-visible:ring-sky-600/50 active:bg-sky-200/80 active:text-sky-800 dark:hover:border-white dark:hover:bg-white/25 dark:hover:text-white dark:focus-visible:border-white dark:focus-visible:bg-white/25 dark:focus-visible:ring-white/50 dark:active:bg-white/30': variant == 'outlined' and (href or clickable),
+      'hover:border-sky-700 hover:bg-sky-100 hover:text-sky-700 focus-visible:border-sky-700 focus-visible:bg-sky-100 focus-visible:ring-sky-600/50 active:bg-sky-200/80 active:text-sky-800 dark:hover:border-white dark:hover:bg-white/25 dark:hover:text-white dark:focus-visible:border-white dark:focus-visible:bg-white/25 dark:focus-visible:ring-white/50 dark:active:bg-white/30': variant == 'outlined' and (url or clickable),
       'min-h-20 px-6 text-xs [&_svg]:size-12': size == 'sm',
       'min-h-28 px-8 text-sm [&_svg]:size-16': size == 'md',
       'min-h-36 px-10 text-base [&_svg]:size-20': size == 'lg',
     }, class),
-  }) %}
+  } %}
     {{ icon ? Icon({
       name: icon,
       size: 'none',

--- a/templates/_components/video.twig
+++ b/templates/_components/video.twig
@@ -31,7 +31,7 @@
 
   <div class="{{ classNames('relative', class) }}">
     {{ Button({
-      href: '#' ~ id,
+      url: '#' ~ id,
       variant: 'text',
       class: 'sr-only focus-visible:not-sr-only',
       text: 'Skip past video'

--- a/templates/_partials/header.twig
+++ b/templates/_partials/header.twig
@@ -10,7 +10,7 @@
 
 {{ Button({
   text: 'Skip to main content',
-  href: '#content',
+  url: '#content',
   class: 'sr-only focus:not-sr-only focus:absolute focus:top-16 focus:left-16 focus:z-50 focus:p-16 focus:z-max',
 }) }}
 

--- a/templates/parts-kit/call-to-action/default.twig
+++ b/templates/parts-kit/call-to-action/default.twig
@@ -3,7 +3,7 @@
 {{ CallToAction({
   title: 'Lorem ipsum dolor sit amet',
   text: 'Lorem ipsum dolor sit amet, consectetur adipiscing e lit. Nulla facilisi. Nulla facilisi. Nulla facilisi.',
-  href: '#TEST',
+  url: '#TEST',
   buttonText: 'Button',
-  newTab: true,
+  target: '_blank',
 }) }}

--- a/templates/parts-kit/card/card-with-icon.twig
+++ b/templates/parts-kit/card/card-with-icon.twig
@@ -3,8 +3,8 @@
 <div class="grid grid-cols-3 gap-16 mb-48">
   {% for i in 1..3 %}
     {{ CardIcon({
-      href: i == 2 ? '#TEST' : null,
-      newTab: i == 2,
+      url: i == 2 ? '#TEST' : null,
+      target: i == 2 ? '_blank' : null,
       icon: 'clock',
       title: 'Lorem ipsum dolor sit amet',
       description: 'Cillum dolor nisi et sunt in in et ullamco eiusmod duis aute et fugiat excepteur. Sit irure consectetur anim do aliqua excepteur amet nulla magna enim proident incididunt ipsum.',
@@ -15,8 +15,8 @@
 <div class="grid grid-cols-3 gap-16 mb-48">
   {% for i in 1..3 %}
     {{ CardIcon({
-      href: i == 2 ? '#TEST' : null,
-      newTab: i == 2,
+      url: i == 2 ? '#TEST' : null,
+      target: i == 2 ? '_blank' : null,
       align: 'center',
       icon: 'clock',
       title: 'Lorem ipsum dolor sit amet',

--- a/templates/parts-kit/card/card-with-image.twig
+++ b/templates/parts-kit/card/card-with-image.twig
@@ -4,8 +4,8 @@
   {% for i in 1..3 %}
     {{ CardImage({
       image: craft.assets.one(),
-      href: i == 2 ? '#TEST' : null,
-      newTab: i == 2,
+      url: i == 2 ? '#TEST' : null,
+      target: i == 2 ? '_blank' : null,
       sizes: {
         default: '33vw',
       },
@@ -20,8 +20,8 @@
     {{ CardImage({
       align: 'center',
       image: craft.assets.one(),
-      href: i == 2 ? '#TEST' : null,
-      newTab: i == 2,
+      url: i == 2 ? '#TEST' : null,
+      target: i == 2 ? '_blank' : null,
       ratio: 1/1,
       sizes: {
         default: '33vw',

--- a/templates/parts-kit/tag/default.twig
+++ b/templates/parts-kit/tag/default.twig
@@ -17,7 +17,7 @@
         text: 'Tag ' ~ size ~ ' link',
         size: size,
         variant: variant,
-        href: '#TEST',
+        url: '#TEST',
       }) }}
 
       {{ Tag({


### PR DESCRIPTION
## Summary
Aligns Button and other link-aware macros (CardIcon, CardImage, Tag, CallToAction) to use Craft's link-field / entry vocabulary so callers can pass through field values without renaming.

## Changes
**Button** (`_components/button.twig`):
- `href` → `url`
- `newTab` (bool) → `target` (string, e.g. `'_blank'`)
- Adds `ariaLabel` prop (falls back to `attrs['aria-label']`)
- Adds `download` prop (bool / string / null)
- `rel` automatically set to `noopener noreferrer` when `target == '_blank'`
- Switches from `attrs | merge(...)` to spread syntax `{...attrs, ...}` per the issue's suggestion

**CardIcon, CardImage, Tag, CallToAction:**
- `href` → `url`, `newTab` → `target` (string), with the same auto-`rel` treatment on link variants

**Callers updated:**
- `_blocks/_callToAction.twig`, `_blocks/_cardGrid.twig`
- `_components/pagination.twig`, `_components/video.twig`, `_partials/header.twig`
- Parts-kit demos for card, tag, call-to-action

## Breaking change
Renames public props on five macros. These won't integrate well into a previously built Craft Site Starter project, but that's never been a goal for this project. 

## Test plan
- [ ] `/parts-kit/button/default` — all variants/sizes render unchanged
- [ ] `/parts-kit/card/card-with-icon` and `/card-with-image` — middle card opens in new tab and HTML carries `rel="noopener noreferrer"`
- [ ] `/parts-kit/tag/default` — link tag navigates
- [ ] `/parts-kit/call-to-action/default` — button opens in new tab
- [ ] Page with Call-to-Action / Card Grid block — link-field "open in new tab" toggle still works
- [ ] Keyboard-focus the global header's "Skip to main content" link
- [ ] Page with video block — "Skip past video" link works
- [ ] Paginated entries page — Previous / page-number / Next links navigate