### PR TITLE
[#150] Add globally controlled llms.txt

### DIFF
--- a/config/project/entryTypes/aiSettings--b818de5a-9910-4caa-8bc7-1518eec27fa9.yaml
+++ b/config/project/entryTypes/aiSettings--b818de5a-9910-4caa-8bc7-1518eec27fa9.yaml
@@ -1,0 +1,42 @@
+allowLineBreaksInTitles: false
+color: null
+description: null
+fieldLayouts:
+  615e51a2-a869-44eb-a776-c94f0accb177:
+    cardThumbAlignment: end
+    tabs:
+      -
+        elementCondition: null
+        elements:
+          -
+            dateAdded: '2026-05-07T02:40:43+00:00'
+            editCondition: null
+            elementCondition: null
+            elementEditCondition: null
+            fieldUid: 7a701601-ee6c-4d56-8bd0-efa7719f6a67 # Code
+            handle: llmsTxtContent
+            instructions: "Add content that appears at the `/llms.txt` path. \r\n\r\nLeave this field empty to disable this feature and URL path. \r\n\r\n"
+            label: 'llms.txt content'
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: cb4138c6-9843-4b43-9b17-f74f183f36d1
+            userCondition: null
+            warning: null
+            width: 100
+        name: Content
+        uid: 92c1ec88-5b06-4a84-b4c8-7704960f923d
+        userCondition: null
+    thumbFieldKey: null
+handle: aiSettings
+hasTitleField: false
+icon: null
+name: 'AI Settings'
+showSlugField: true
+showStatusField: true
+slugTranslationKeyFormat: null
+slugTranslationMethod: site
+titleFormat: null
+titleTranslationKeyFormat: null
+titleTranslationMethod: site
+uiLabelFormat: '{title}'

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1772753181
+dateModified: 1778121163
 elementSources:
   craft\elements\Entry:
     -
@@ -8,6 +8,7 @@ elementSources:
       defaultViewMode: ''
       disabled: false
       key: '*'
+      page: Entries
       tableAttributes:
         - status
         - section
@@ -17,12 +18,17 @@ elementSources:
       type: native
     -
       heading: Singles
+      key: 'heading:aeacc05c-5467-44a9-987f-b6b16d96b7de'
+      page: Entries
       type: heading
     -
       key: 'single:969acdd6-6362-41b1-b782-6bbd43a8a6b4' # Home
+      page: Entries
       type: native
     -
       heading: Globals
+      key: 'heading:5af39cb5-3202-4e4e-b093-23ef87051c97'
+      page: Entries
       type: heading
     -
       defaultSort:
@@ -31,12 +37,17 @@ elementSources:
       defaultViewMode: ''
       disabled: false
       key: 'single:b4bfeb63-5bc4-4368-b4c9-408f7bac68fc' # Global Code
+      page: Globals
       tableAttributes:
         - status
         - postDate
         - expiryDate
         - link
       type: native
+elementSourcesPages:
+  craft\elements\Entry:
+    Globals:
+      icon: globe
 email:
   fromEmail: $SYSTEM_EMAIL_FROM
   fromName: 'Viget Craft Starter'

--- a/config/project/project.yaml
+++ b/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1778121163
+dateModified: 1778123830
 elementSources:
   craft\elements\Entry:
     -
@@ -26,11 +26,6 @@ elementSources:
       page: Entries
       type: native
     -
-      heading: Globals
-      key: 'heading:5af39cb5-3202-4e4e-b093-23ef87051c97'
-      page: Entries
-      type: heading
-    -
       defaultSort:
         - id
         - asc
@@ -43,6 +38,10 @@ elementSources:
         - postDate
         - expiryDate
         - link
+      type: native
+    -
+      key: 'single:616ddfb4-d727-49d5-9da2-10382368d299' # AI Settings
+      page: Globals
       type: native
 elementSourcesPages:
   craft\elements\Entry:
@@ -100,6 +99,7 @@ meta:
     101b4db6-8914-45eb-a661-180b15f70894: 'Footer Navigation' # Footer Navigation
     534ccdd8-7abd-4300-a102-71885b21c126: 'Call To Action' # Call To Action
     570fb481-ad97-46db-8bad-f7b0fd90e831: Image # Image
+    616ddfb4-d727-49d5-9da2-10382368d299: 'AI Settings' # AI Settings
     805d8826-faed-4186-9b88-f509eb9b07e6: 'Viget Craft Starter' # Viget Craft Starter
     896b8f2a-ed0c-42c9-b5fd-ba8668fc6784: 'Rich Text' # Rich Text
     969acdd6-6362-41b1-b782-6bbd43a8a6b4: Home # Home
@@ -110,6 +110,7 @@ meta:
     ac3b0590-d417-429e-aa1f-96be3c79a5b0: 'Media Type' # Media Type
     b3d7753a-c7ad-4f33-aca8-df63277e9b42: 'Primary Navigation' # Primary Navigation
     b4bfeb63-5bc4-4368-b4c9-408f7bac68fc: 'Global Code' # Global Code
+    b818de5a-9910-4caa-8bc7-1518eec27fa9: 'AI Settings' # AI Settings
     c52a9170-652b-4d92-a226-69894b1822ed: 'Rich Text: Simple' # Rich Text: Simple
     cbf3aeac-588c-4aeb-9573-6f1920206abf: 'Code Block' # Code Block
     cd489d3c-f914-475c-a270-ab926e4e7485: 'Rich Text' # Rich Text

--- a/config/project/sections/aiSettings--616ddfb4-d727-49d5-9da2-10382368d299.yaml
+++ b/config/project/sections/aiSettings--616ddfb4-d727-49d5-9da2-10382368d299.yaml
@@ -1,0 +1,16 @@
+defaultPlacement: end
+enableVersioning: true
+entryTypes:
+  -
+    uid: b818de5a-9910-4caa-8bc7-1518eec27fa9 # AI Settings
+handle: aiSettings
+maxAuthors: 1
+name: 'AI Settings'
+propagationMethod: all
+siteSettings:
+  35b563a0-4662-40b9-b885-a8450a2868d9: # Viget Craft Starter
+    enabledByDefault: true
+    hasUrls: true
+    template: null
+    uriFormat: ai-settings
+type: single

--- a/config/routes.php
+++ b/config/routes.php
@@ -9,4 +9,8 @@
  * https://craftcms.com/docs/5.x/system/routing.html
  */
 
-return [];
+return [
+    'llms.txt' => [
+        'template' => '_llms.twig',
+    ],
+];

--- a/templates/_llms.twig
+++ b/templates/_llms.twig
@@ -1,0 +1,9 @@
+{%- set llmsTxtContent = aiSettings.llmsTxtContent|trim -%}
+
+{%- if not llmsTxtContent -%}
+  {%- exit 404 -%}
+{%- endif -%}
+
+{%- header "Content-Type: text/plain" -%}
+
+{{- llmsTxtContent|raw -}}


### PR DESCRIPTION
## Summary

Resolves #150 by giving clients an optional, CMS-controlled `llms.txt` route — no third-party plugin required. Skeptical of the practical value (per the linked Reboot experiment in the ticket), but cheap to provide as an opt-in.

## Changes

- **AI Settings globals entry** (`config/project/...`): new `ai-settings` single section + entry type with an `llmsTxtContent` plain-text field. Lives alongside the existing globals entry index introduced in 6edcb9f.
- **Route** (`config/routes.php`): maps `llms.txt` → `_llms.twig`.
- **Template** (`templates/_llms.twig`): trims `aiSettings.llmsTxtContent`; if empty, returns 404 so we don't serve a blank file; otherwise sets `Content-Type: text/plain` and outputs the raw value.

## Test plan

- [ ] In the CP, open **Globals → AI Settings**, leave `llmsTxtContent` empty, and confirm `/llms.txt` returns a 404
- [ ] Add some content (e.g. ``# My Site`` / ``- About: ...``), save, and confirm `/llms.txt` returns it as `text/plain` with no surrounding HTML
- [ ] `curl -I` the URL to confirm the `Content-Type: text/plain` response header

## Screenshots / Video 


https://github.com/user-attachments/assets/a9b8dce1-1737-4e8b-8ba0-424a673fed59

